### PR TITLE
Adds missing php syntax highlighting to example

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -82,7 +82,7 @@ $engine = new CipherSweet($provider);
 If you're using FIPSCrypto instead of ModernCrypto, you just need to pass
 it once to the `KeyProvider` and the rest is handled for you.
 
-```
+```php
 <?php
 use ParagonIE\ConstantTime\Hex;
 use ParagonIE\CipherSweet\Backend\ModernCrypto;


### PR DESCRIPTION
Small thing...but stuff like this sticks out like a sore thumb to me 😄

Won't hurt my feelings one bit if you close this and just fix it yourself