### PR TITLE
New option: Flat indexes.

### DIFF
--- a/src/Backend/ModernCrypto.php
+++ b/src/Backend/ModernCrypto.php
@@ -83,12 +83,16 @@ class ModernCrypto implements BackendInterface
         $nonce = Binary::safeSubstr($decoded, 0, self::NONCE_SIZE);
         $encrypted = Binary::safeSubstr($decoded, self::NONCE_SIZE);
 
-        return SodiumCompat::crypto_aead_xchacha20poly1305_ietf_decrypt(
+        $plaintext = SodiumCompat::crypto_aead_xchacha20poly1305_ietf_decrypt(
             $encrypted,
             $nonce . $aad,
             $nonce,
             $key->getRawKey()
         );
+        if (!is_string($plaintext)) {
+            throw new \SodiumException("Invalid ciphertext");
+        }
+        return $plaintext;
     }
 
     /**

--- a/src/EncryptedMultiRows.php
+++ b/src/EncryptedMultiRows.php
@@ -18,6 +18,11 @@ class EncryptedMultiRows
     protected $engine;
 
     /**
+     * @var bool $flatIndexes
+     */
+    protected $flatIndexes;
+
+    /**
      * @var array<string, EncryptedRow> $tables
      */
     protected $tables = [];
@@ -26,10 +31,12 @@ class EncryptedMultiRows
      * EncryptedFieldSet constructor.
      *
      * @param CipherSweet $engine
+     * @param bool $useFlatIndexes
      */
-    public function __construct(CipherSweet $engine)
+    public function __construct(CipherSweet $engine, $useFlatIndexes = false)
     {
         $this->engine = $engine;
+        $this->flatIndexes = $useFlatIndexes;
     }
 
     /**
@@ -269,7 +276,7 @@ class EncryptedMultiRows
      * @param string $tableName
      * @param string $indexName
      * @param array $row
-     * @return array<string, string>
+     * @return array<string, string>|string
      *
      * @throws ArrayKeyException
      * @throws BlindIndexNotFoundException
@@ -287,7 +294,7 @@ class EncryptedMultiRows
      *
      * @param string $tableName
      * @param array $row
-     * @return array<string, array<string, string>>
+     * @return array<string, array<string, string>|string>
      *
      * @throws ArrayKeyException
      * @throws CryptoOperationException
@@ -313,7 +320,7 @@ class EncryptedMultiRows
      * ]
      *
      * @param array<string, array> $rows
-     * @return array<string, array<string, array<string, string>>>
+     * @return array<string, array<string, array<string, string>|string>>
      *
      * @throws ArrayKeyException
      * @throws Exception\CryptoOperationException
@@ -346,6 +353,7 @@ class EncryptedMultiRows
         }
         /** @var EncryptedRow $encryptedRow */
         $encryptedRow = $this->tables[$tableName];
+        $encryptedRow->setFlatIndexes($this->flatIndexes);
         return $encryptedRow;
     }
 
@@ -384,7 +392,7 @@ class EncryptedMultiRows
      * ]
      *
      * @param array<string, array<string, string|int|float|bool|null>> $rows
-     * @return array{0:array<string, array<string, string>>, 1:array<string, array<string, array<string, string>>>}
+     * @return array{0:array<string, array<string, string>>, 1:array<string, array<string, array<string, string>|string>>}
      *
      * @throws ArrayKeyException
      * @throws CryptoOperationException
@@ -403,6 +411,7 @@ class EncryptedMultiRows
                     ->encryptRow($row);
                 $indexes[$table] = $this
                     ->getEncryptedRowObjectForTable($table)
+                    ->setFlatIndexes($this->flatIndexes)
                     ->getAllBlindIndexes($row);
             }
         }
@@ -423,5 +432,23 @@ class EncryptedMultiRows
     public function getEngine()
     {
         return $this->engine;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getFlatIndexes()
+    {
+        return $this->flatIndexes;
+    }
+
+    /**
+     * @param bool $bool
+     * @return self
+     */
+    public function setFlatIndexes($bool)
+    {
+        $this->flatIndexes = $bool;
+        return $this;
     }
 }

--- a/tests/EncryptedFieldTest.php
+++ b/tests/EncryptedFieldTest.php
@@ -240,6 +240,48 @@ class EncryptedFieldTest extends TestCase
      * @throws BlindIndexNotFoundException
      * @throws CryptoOperationException
      */
+    public function testFIPSBlindIndexFlatAndFast()
+    {
+        $ssn = $this->getExampleField($this->fipsEngine, false, true);
+        $ssn->setFlatIndexes(true);
+
+        $this->assertEquals(
+            '924b',
+            $ssn->getBlindIndex('111-11-1111', 'contact_ssn_last_four')
+        );
+        $this->assertEquals(
+            'be3b',
+            $ssn->getBlindIndex('111-11-2222', 'contact_ssn_last_four')
+        );
+        $this->assertEquals(
+            '3cd3',
+            $ssn->getBlindIndex('123-45-6788', 'contact_ssn_last_four')
+        );
+        $this->assertEquals(
+            '4bb1',
+            $ssn->getBlindIndex('123-45-6789', 'contact_ssn_last_four')
+        );
+        $this->assertEquals(
+            '256e1182',
+            $ssn->getBlindIndex('invalid guess 123', 'contact_ssn')
+        );
+        $this->assertEquals(
+            'd2a774dc',
+            $ssn->getBlindIndex('123-45-6789', 'contact_ssn')
+        );
+
+        $random = $this->getExampleField($this->fipsRandom, true, true);
+        $this->assertNotEquals(
+            'ee10e07b213a922075a6ada22514528c',
+            $random->getBlindIndex('123-45-6789', 'contact_ssn')
+        );
+    }
+
+    /**
+     * @throws BlindIndexNameCollisionException
+     * @throws BlindIndexNotFoundException
+     * @throws CryptoOperationException
+     */
     public function testModernBlindIndex()
     {
         if (!\ParagonIE_Sodium_Compat::crypto_pwhash_is_available()) {
@@ -278,6 +320,7 @@ class EncryptedFieldTest extends TestCase
             $random->getBlindIndex('123-45-6789', 'contact_ssn')
         );
     }
+
     /**
      * @throws BlindIndexNameCollisionException
      * @throws BlindIndexNotFoundException
@@ -314,6 +357,47 @@ class EncryptedFieldTest extends TestCase
         $random = $this->getExampleField($this->naclRandom, true, true);
         $this->assertNotEquals(
             ['type' => '2iztg3wbd7j5a', 'value' => '499db5085e715c2f167c1e2c02f1c80f'],
+            $random->getBlindIndex('123-45-6789', 'contact_ssn')
+        );
+    }
+
+    /**
+     * @throws BlindIndexNameCollisionException
+     * @throws BlindIndexNotFoundException
+     * @throws CryptoOperationException
+     */
+    public function testModernBlindIndexFlatAndFast()
+    {
+        $ssn = $this->getExampleField($this->naclEngine, false, true);
+        $ssn->setFlatIndexes(true);
+        $this->assertEquals(
+            '7843',
+            $ssn->getBlindIndex('111-11-1111', 'contact_ssn_last_four')
+        );
+        $this->assertEquals(
+            'd246',
+            $ssn->getBlindIndex('111-11-2222', 'contact_ssn_last_four')
+        );
+        $this->assertEquals(
+            '4882',
+            $ssn->getBlindIndex('123-45-6788', 'contact_ssn_last_four')
+        );
+        $this->assertEquals(
+            '92c8',
+            $ssn->getBlindIndex('123-45-6789', 'contact_ssn_last_four')
+        );
+        $this->assertEquals(
+            'b6fd11a1',
+            $ssn->getBlindIndex('invalid guess 123', 'contact_ssn')
+        );
+        $this->assertEquals(
+            '30c7cc68',
+            $ssn->getBlindIndex('123-45-6789', 'contact_ssn')
+        );
+
+        $random = $this->getExampleField($this->naclRandom, true, true);
+        $this->assertNotEquals(
+            '499db5085e715c2f167c1e2c02f1c80f',
             $random->getBlindIndex('123-45-6789', 'contact_ssn')
         );
     }

--- a/tests/EncryptedMultiRowsTest.php
+++ b/tests/EncryptedMultiRowsTest.php
@@ -77,6 +77,23 @@ class EncryptedMultiRowsTest extends TestCase
         );
     }
 
+    public function testFlatInherits()
+    {
+        $engines = [$this->fipsEngine, $this->fipsRandom, $this->naclEngine, $this->naclRandom];
+        foreach ($engines as $engine) {
+            $mr = (new EncryptedMultiRows($engine, true))
+                ->addTable('foo')
+                ->addTable('bar');
+
+            foreach ($mr->listTables() as $table) {
+                $this->assertSame(
+                    $mr->getFlatIndexes(),
+                    $mr->getEncryptedRowObjectForTable($table)->getFlatIndexes()
+                );
+            }
+        }
+    }
+
     public function testEncryptedMultiRowsSetup()
     {
         $engines = [$this->fipsEngine, $this->fipsRandom, $this->naclEngine, $this->naclRandom];


### PR DESCRIPTION
Instead of returning ['type' => 'something1', 'value' => 'something2'],
this configuration setting only returns 'something2'.