### PR TITLE
Private methods cannot be final as they are never overridden by other classes

### DIFF
--- a/src/Util.php
+++ b/src/Util.php
@@ -370,7 +370,7 @@ abstract class Util
     /**
      * @return bool|null
      */
-    private static final function getWrongEndianness()
+    private static function getWrongEndianness()
     {
         $x = \pack('d', 1.618);
         if ($x === "\x17\xd9\xce\xf7\x53\xe3\xf9\x3f") {


### PR DESCRIPTION
fixes PHP 8 warning.

Closes #56

