### PR TITLE
Version 3 Development

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,72 @@
+name: CI
+
+on: [push]
+
+jobs:
+  old:
+    name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        operating-system: ['ubuntu-16.04']
+        php-versions: ['5.5', '5.6', '7.0']
+        phpunit-versions: ['latest']
+        include:
+          - operating-system: 'ubuntu-16.04'
+            php-versions: '5.6'
+            phpunit-versions: '7.5.20'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: mbstring, intl, sodium
+          ini-values: post_max_size=256M, max_execution_time=180
+          tools: psalm, phpunit:${{ matrix.phpunit-versions }}
+
+      - name: Install dependencies
+        run: composer self-update --1; composer install
+
+      - name: PHPUnit tests
+        uses: php-actions/phpunit@v2
+        with:
+          memory_limit: 256M
+
+  modern:
+    name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        operating-system: ['ubuntu-latest']
+        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0']
+        phpunit-versions: ['latest']
+        include:
+          - operating-system: 'ubuntu-latest'
+            php-versions: '7.4'
+            phpunit-versions: '9.5.4'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: mbstring, intl, sodium
+          ini-values: post_max_size=256M, max_execution_time=180
+          tools: psalm, phpunit:${{ matrix.phpunit-versions }}
+
+      - name: Install dependencies
+        run: composer install
+
+      - name: PHPUnit tests
+        uses: php-actions/phpunit@v2
+        with:
+          memory_limit: 256M
+
+      - name: Static Analysis
+        if: contains(['7.4', '8.0], ${{ matrix.php-version }})
+        run: composer static-analysis

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,11 @@ matrix:
     - php: "7.0"
       env: USE_PSALM=0
     - php: "7.1"
-      env: USE_PSALM=1
+      env: USE_PSALM=0
     - php: "7.2"
-      env: USE_PSALM=1
+      env: USE_PSALM=0
     - php: "7.3"
-      env: USE_PSALM=1
+      env: USE_PSALM=0
     - php: "7.4"
       env: USE_PSALM=1
     - php: "8.0"
@@ -32,7 +32,7 @@ matrix:
 
 install:
     - travis_retry composer install
-    - if [[ $USE_PSALM -eq 1 ]]; then travis_retry composer require --dev "vimeo/psalm:^3"; fi
+    - if [[ $USE_PSALM -eq 1 ]]; then travis_retry composer require --dev "vimeo/psalm:^4"; fi
 
 script:
     - vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # CipherSweet
 
+![Build Status](https://github.com/paragonie/ciphersweet/actions/workflows/ci.yml/badge.svg)
 [![Linux Build Status](https://travis-ci.org/paragonie/ciphersweet.svg?branch=master)](https://travis-ci.org/paragonie/ciphersweet)
 [![Latest Stable Version](https://poser.pugx.org/paragonie/ciphersweet/v/stable)](https://packagist.org/packages/paragonie/ciphersweet)
 [![Latest Unstable Version](https://poser.pugx.org/paragonie/ciphersweet/v/unstable)](https://packagist.org/packages/paragonie/ciphersweet)

--- a/autoload-ci.php
+++ b/autoload-ci.php
@@ -1,0 +1,4 @@
+<?php
+
+require_once __DIR__ . '/vendor/autoload.php';
+require_once __DIR__ . '/tests/CreatesEngines.php';

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "ext-json": "*",
     "ext-openssl": "*",
     "paragonie/constant_time_encoding": "^1.0.4|^2",
-    "paragonie/sodium_compat": "^1.14"
+    "paragonie/sodium_compat": ">= 1.15.2 <2"
   },
   "require-dev": {
     "phpunit/phpunit": "^4|^5|^6|^7"

--- a/composer.json
+++ b/composer.json
@@ -37,9 +37,10 @@
     "paragonie/sodium_compat": ">= 1.15.2 <2"
   },
   "require-dev": {
-    "phpunit/phpunit": "^4|^5|^6|^7"
+    "phpunit/phpunit": "^4|^5|^6|^7|^8|^9"
   },
   "scripts": {
+    "static-analysis": "psalm --no-cache --no-suggestions",
     "test": "phpunit"
   }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit>
+<phpunit bootstrap="autoload-ci.php">
     <testsuites>
         <testsuite name="CipherSweet Minimal Test Suite">
             <directory>tests</directory>

--- a/psalm.xml
+++ b/psalm.xml
@@ -9,7 +9,13 @@
     <issueHandlers>
         <MoreSpecificImplementedParamType errorLevel="suppress" /><!-- this is fine -->
         <RedundantConditionGivenDocblockType errorLevel="suppress" /><!-- we're being explicit -->
+        <RedundantCastGivenDocblockType errorLevel="suppress" /><!-- we're being explicit -->
         <InternalMethod errorLevel="suppress" /><!-- it's internal to sodium_compat but we still need to use it -->
         <DocblockTypeContradiction errorLevel="info" /><!-- We're still supporting PHP 5 -->
+        <UnnecessaryVarAnnotation errorLevel="suppress" />
+        <UnusedFunctionCall errorLevel="info" />
+        <UnusedVariable errorLevel="info" />
+	    <RedundantCast errorLevel="suppress" />
+        <MixedReturnTypeCoercion errorLevel="info" />
     </issueHandlers>
 </psalm>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <psalm
+    autoloader="autoload-ci.php"
     totallyTyped="true"
 >
     <projectFiles>
@@ -17,5 +18,6 @@
         <UnusedVariable errorLevel="info" />
 	    <RedundantCast errorLevel="suppress" />
         <MixedReturnTypeCoercion errorLevel="info" />
+        <UnresolvableInclude errorLevel="info" />
     </issueHandlers>
 </psalm>

--- a/src/Backend/BoringCrypto.php
+++ b/src/Backend/BoringCrypto.php
@@ -78,6 +78,9 @@ class BoringCrypto implements BackendInterface, MultiTenantSafeBackendInterface
             $this->getEncryptionKey($key)->getRawKey()
         );
         $cipherLength = SodiumUtil::strlen($ciphertext);
+        if (is_null($aad)) {
+            $aad = '';
+        }
         $aadLength = SodiumUtil::strlen($aad);
         // T := BLAKE2b-MAC (nonce || len(aad) || aad || len(C) || C)
         $mac = SodiumCompat::crypto_generichash(
@@ -118,6 +121,9 @@ class BoringCrypto implements BackendInterface, MultiTenantSafeBackendInterface
 
         // T := BLAKE2b-MAC ( len(aad) || aad || len(C) || C)
         $cipherLength = SodiumUtil::strlen($encrypted);
+        if (is_null($aad)) {
+            $aad = '';
+        }
         $aadLength = SodiumUtil::strlen($aad);
         $calcMac = SodiumCompat::crypto_generichash(
             ((string) static::MAGIC_HEADER) . $nonce . $aadLength . $aad . $cipherLength . $encrypted,

--- a/src/Backend/BoringCrypto.php
+++ b/src/Backend/BoringCrypto.php
@@ -1,0 +1,451 @@
+<?php
+namespace ParagonIE\CipherSweet\Backend;
+
+use ParagonIE\CipherSweet\Backend\Key\SymmetricKey;
+use ParagonIE\CipherSweet\Constants;
+use ParagonIE\CipherSweet\Contract\BackendInterface;
+use ParagonIE\CipherSweet\Exception\CryptoOperationException;
+use ParagonIE\CipherSweet\Exception\InvalidCiphertextException;
+use ParagonIE\CipherSweet\Util;
+use ParagonIE\ConstantTime\Base32;
+use ParagonIE\ConstantTime\Base64UrlSafe;
+use ParagonIE\ConstantTime\Binary;
+use ParagonIE_Sodium_Compat as SodiumCompat;
+use ParagonIE\Sodium\Core\ChaCha20;
+use ParagonIE\Sodium\Core\HChaCha20;
+use ParagonIE\Sodium\Core\XChaCha20;
+use ParagonIE_Sodium_Core_Util as SodiumUtil;
+
+/**
+ * Class BoringCrypto
+ *
+ * This backend dispenses with the Poly1305 authenticator and instead uses BLAKE2b-MAC (B2MAC).
+ *
+ * @package ParagonIE\CipherSweet\Backend
+ */
+class BoringCrypto implements BackendInterface
+{
+    const MAGIC_HEADER = "brng:";
+    const NONCE_SIZE = 24;
+    const MAC_SIZE = 32;
+
+    /**
+     * @param SymmetricKey $key
+     * @return SymmetricKey
+     * @throws \SodiumException
+     */
+    protected function getEncryptionKey(SymmetricKey $key)
+    {
+        return new SymmetricKey(
+            SodiumCompat::crypto_generichash('message-encryption', $key->getRawKey(), 32)
+        );
+    }
+
+    /**
+     * @param SymmetricKey $key
+     * @return SymmetricKey
+     * @throws \SodiumException
+     */
+    protected function getIntegrityKey(SymmetricKey $key)
+    {
+        return new SymmetricKey(
+            SodiumCompat::crypto_generichash('message-integrity', $key->getRawKey(), 32)
+        );
+    }
+
+    /**
+     * Encrypt a message using XChaCha20-B2MAC
+     *
+     * @param string $plaintext
+     * @param SymmetricKey $key
+     * @param string $aad       Additional authenticated data
+     *
+     * @return string
+     *
+     * @throws CryptoOperationException
+     * @throws \SodiumException
+     */
+    public function encrypt($plaintext, SymmetricKey $key, $aad = '')
+    {
+        try {
+            $nonce = \random_bytes(self::NONCE_SIZE);
+        } catch (\Exception $ex) {
+            throw new CryptoOperationException('CSPRNG failure', 0, $ex);
+        }
+        $ciphertext = XChaCha20::streamXorIc(
+            $plaintext,
+            $nonce,
+            $this->getEncryptionKey($key)->getRawKey()
+        );
+        $cipherLength = SodiumUtil::strlen($ciphertext);
+        $aadLength = SodiumUtil::strlen($aad);
+        // T := BLAKE2b-MAC (nonce || len(aad) || aad || len(C) || C)
+        $mac = SodiumCompat::crypto_generichash(
+            ((string) static::MAGIC_HEADER) . $nonce . $aadLength . $aad . $cipherLength . $ciphertext,
+            $this->getIntegrityKey($key)->getRawKey(),
+            self::MAC_SIZE
+        );
+        return (string) (self::MAGIC_HEADER) . Base64UrlSafe::encode($nonce . $mac . $ciphertext);
+    }
+
+    /**
+     * Decrypt a message using XChaCha20-B2MAC
+     *
+     * @param string $ciphertext
+     * @param SymmetricKey $key
+     * @param string $aad       Additional authenticated data
+     *
+     * @return string
+     * @throws InvalidCiphertextException
+     * @throws \SodiumException
+     */
+    public function decrypt($ciphertext, SymmetricKey $key, $aad = '')
+    {
+        // Make sure we're using the correct version:
+        $header = Binary::safeSubstr($ciphertext, 0, 5);
+        if (!SodiumUtil::hashEquals($header, self::MAGIC_HEADER)) {
+            throw new InvalidCiphertextException('Invalid ciphertext header.');
+        }
+
+        // Decompose the encrypted message into its constituent parts:
+        $decoded = Base64UrlSafe::decode(Binary::safeSubstr($ciphertext, 5));
+        if (Binary::safeStrlen($decoded) < (self::NONCE_SIZE + self::MAC_SIZE)) {
+            throw new InvalidCiphertextException('Message is too short.');
+        }
+        $nonce = Binary::safeSubstr($decoded, 0, self::NONCE_SIZE);
+        $storedMac = Binary::safeSubstr($decoded, self::NONCE_SIZE, self::MAC_SIZE);
+        $encrypted = Binary::safeSubstr($decoded, self::NONCE_SIZE + self::MAC_SIZE);
+
+        // T := BLAKE2b-MAC ( len(aad) || aad || len(C) || C)
+        $cipherLength = SodiumUtil::strlen($encrypted);
+        $aadLength = SodiumUtil::strlen($aad);
+        $calcMac = SodiumCompat::crypto_generichash(
+            ((string) static::MAGIC_HEADER) . $nonce . $aadLength . $aad . $cipherLength . $encrypted,
+            $this->getIntegrityKey($key)->getRawKey(),
+            self::MAC_SIZE
+        );
+        if (!Util::hashEquals($calcMac, $storedMac)) {
+            throw new \SodiumException("Invalid ciphertext");
+        }
+
+        return XChaCha20::streamXorIc(
+            $encrypted,
+            $nonce,
+            $this->getEncryptionKey($key)->getRawKey()
+        );
+    }
+
+    /**
+     * @param string $plaintext
+     * @param SymmetricKey $key
+     * @param int|null $bitLength
+     *
+     * @return string
+     * @throws \SodiumException
+     */
+    public function blindIndexFast(
+        $plaintext,
+        SymmetricKey $key,
+        $bitLength = null
+    ) {
+        if (\is_null($bitLength)) {
+            $bitLength = 256;
+        }
+        if ($bitLength > 512) {
+            throw new \SodiumException('Output length is too high');
+        }
+        if ($bitLength > 256) {
+            $hashLength = $bitLength >> 3;
+        } else {
+            $hashLength = 32;
+        }
+        $hash = SodiumCompat::crypto_generichash(
+            $plaintext,
+            $key->getRawKey(),
+            $hashLength
+        );
+        return Util::andMask($hash, $bitLength);
+    }
+
+    /**
+     * @param string $plaintext
+     * @param SymmetricKey $key
+     * @param int|null $bitLength
+     * @param array $config
+     *
+     * @return string
+     * @throws \SodiumException
+     */
+    public function blindIndexSlow(
+        $plaintext,
+        SymmetricKey $key,
+        $bitLength = null,
+        array $config = []
+    ) {
+        if (!SodiumCompat::crypto_pwhash_is_available()) {
+            throw new \SodiumException(
+                'Not using the native libsodium bindings'
+            );
+        }
+        $opsLimit = SodiumCompat::CRYPTO_PWHASH_OPSLIMIT_INTERACTIVE;
+        $memLimit = SodiumCompat::CRYPTO_PWHASH_MEMLIMIT_INTERACTIVE;
+
+        if (isset($config['opslimit'])) {
+            if ($config['opslimit'] > $opsLimit) {
+                $opsLimit = (int) $config['opslimit'];
+            }
+        }
+        if (isset($config['memlimit'])) {
+            if ($config['memlimit'] > $memLimit) {
+                $memLimit = (int) $config['memlimit'];
+            }
+        }
+        if (\is_null($bitLength)) {
+            $bitLength = 256;
+        }
+        /** @var int $pwHashLength */
+        $pwHashLength = $bitLength >> 3;
+        if ($pwHashLength < 16) {
+            $pwHashLength = 16;
+        }
+        if ($pwHashLength > 4294967295) {
+            throw new \SodiumException('Output length is far too big');
+        }
+
+        $hash = SodiumCompat::crypto_pwhash(
+            $pwHashLength,
+            $plaintext,
+            SodiumCompat::crypto_generichash($key->getRawKey(), '', 16),
+            $opsLimit,
+            $memLimit,
+            SodiumCompat::CRYPTO_PWHASH_ALG_ARGON2ID13
+        );
+        return Util::andMask($hash, $bitLength);
+    }
+
+    /**
+     * @param string $tableName
+     * @param string $fieldName
+     * @param string $indexName
+     * @return string
+     * @throws \SodiumException
+     */
+    public function getIndexTypeColumn($tableName, $fieldName, $indexName)
+    {
+        $hash = SodiumCompat::crypto_shorthash(
+            Util::pack([$fieldName, $indexName]),
+            SodiumCompat::crypto_generichash($tableName, '', 16)
+        );
+        return Base32::encodeUnpadded($hash);
+    }
+
+    /**
+     * @param string $password
+     * @param string $salt
+     * @return SymmetricKey
+     *
+     * @throws \SodiumException
+     */
+    public function deriveKeyFromPassword($password, $salt)
+    {
+        return new SymmetricKey(
+            SodiumCompat::crypto_pwhash(
+                32,
+                $password,
+                $salt,
+                SODIUM_CRYPTO_PWHASH_OPSLIMIT_INTERACTIVE,
+                SODIUM_CRYPTO_PWHASH_MEMLIMIT_INTERACTIVE
+            )
+        );
+    }
+
+    /**
+     * @param resource $inputFP
+     * @param resource $outputFP
+     * @param SymmetricKey $key
+     * @param int $chunkSize
+     * @return bool
+     *
+     * @throws CryptoOperationException
+     * @throws \SodiumException
+     */
+    public function doStreamDecrypt(
+        $inputFP,
+        $outputFP,
+        SymmetricKey $key,
+        $chunkSize = 8192
+    ) {
+        \fseek($inputFP, 0, SEEK_SET);
+        \fseek($outputFP, 0, SEEK_SET);
+        $adlen = 61; // 5 + 24 + 32
+
+        $header = \fread($inputFP, 5);
+        if (Binary::safeStrlen($header) < 5) {
+            throw new CryptoOperationException('Input file is empty');
+        }
+        if (!Util::hashEquals((string) (static::MAGIC_HEADER), $header)) {
+            throw new CryptoOperationException('Invalid cipher backend for this file');
+        }
+        $storedAuthTag = \fread($inputFP, 32);
+        $salt = \fread($inputFP, 16);
+        $nonce = \fread($inputFP, 24);
+
+        // HChaCha20 step
+        $subkey = HChaCha20::hChaCha20(
+            SodiumUtil::substr($nonce, 0, 16),
+            $this->getEncryptionKey($key)->getRawKey()
+        );
+        $nonceLast = "\x00\x00\x00\x00" . SodiumUtil::substr($nonce, 16, 8);
+        $b2mac = SodiumCompat::crypto_generichash_init(
+            $this->getIntegrityKey($key)->getRawKey(),
+            self::MAC_SIZE
+        );
+        SodiumCompat::crypto_generichash_update($b2mac, (string) (static::MAGIC_HEADER) . $salt . $nonce);
+        $pos = \ftell($inputFP);
+        $chunkMacKey = $this->getIntegrityKey($this->getIntegrityKey($key))->getRawKey();
+
+        $chunkMacs = [];
+        $len = 0;
+        $hash = SodiumCompat::crypto_generichash_init($chunkMacKey, 16);
+        do {
+            $ciphertext = \fread($inputFP, $chunkSize);
+            $len += Binary::safeStrlen($ciphertext);
+            SodiumCompat::crypto_generichash_update($b2mac, $ciphertext);
+            SodiumCompat::crypto_generichash_update($hash, $ciphertext);
+            $hashCopy = '' . $hash;
+            $chunkMacs[] = SodiumCompat::crypto_generichash_final($hashCopy);
+        } while (!\feof($inputFP));
+
+        SodiumCompat::crypto_generichash_update($b2mac, SodiumUtil::store64_le($adlen));
+        SodiumCompat::crypto_generichash_update($b2mac, SodiumUtil::store64_le($len));
+        $authTag = SodiumCompat::crypto_generichash_final($b2mac, self::MAC_SIZE);
+
+        if (!Util::hashEquals($storedAuthTag, $authTag)) {
+            throw new CryptoOperationException('Invalid authentication tag');
+        }
+
+        \fseek($inputFP, $pos, SEEK_SET);
+        $ctr = 1;
+        $ctrIncrease = ($chunkSize + 63) >> 6;
+        $hash = SodiumCompat::crypto_generichash_init($chunkMacKey, 16);
+        do {
+            $ciphertext = \fread($inputFP, $chunkSize);
+
+            SodiumCompat::crypto_generichash_update($hash, $ciphertext);
+            $hashCopy = '' . $hash;
+            $chunk = SodiumCompat::crypto_generichash_final($hashCopy);
+            $storedChunk = \array_shift($chunkMacs);
+            if (!Util::hashEquals($storedChunk, $chunk)) {
+                throw new CryptoOperationException('Race condition');
+            }
+
+            $plaintext = ChaCha20::ietfStreamXorIc(
+                $ciphertext,
+                $nonceLast,
+                $subkey,
+                SodiumUtil::store64_le($ctr)
+            );
+            \fwrite($outputFP, $plaintext);
+            $ctr += $ctrIncrease;
+        } while (!\feof($inputFP));
+
+        if (!empty($chunkMacs)) {
+            // Truncation attack against decryption after MAC validation
+            throw new CryptoOperationException('Race condition');
+        }
+        \rewind($outputFP);
+        return true;
+    }
+
+    /**
+     * @param resource $inputFP
+     * @param resource $outputFP
+     * @param SymmetricKey $key
+     * @param int $chunkSize
+     * @param string $salt
+     * @return bool
+     *
+     * @throws CryptoOperationException
+     * @throws \SodiumException
+     */
+    public function doStreamEncrypt(
+        $inputFP,
+        $outputFP,
+        SymmetricKey $key,
+        $chunkSize = 8192,
+        $salt = Constants::DUMMY_SALT
+    ) {
+        \fseek($inputFP, 0, SEEK_SET);
+        \fseek($outputFP, 0, SEEK_SET);
+        $adlen = 61; // 5 + 24 + 32
+        try {
+            $nonce = \random_bytes(self::NONCE_SIZE);
+        } catch (\Exception $ex) {
+            throw new CryptoOperationException('CSPRNG failure', 0, $ex);
+        };
+
+        // HChaCha20 step
+        $subkey = HChaCha20::hChaCha20(
+            SodiumUtil::substr($nonce, 0, 16),
+            $this->getEncryptionKey($key)->getRawKey()
+        );
+        $nonceLast = "\x00\x00\x00\x00" . SodiumUtil::substr($nonce, 16, 8);
+
+        // Write the header, empty space for a MAC, salts, then nonce.
+        \fwrite($outputFP, (string) static::MAGIC_HEADER, 5);
+        \fwrite($outputFP, str_repeat("\0", 32), 32);
+        \fwrite($outputFP, $salt, 16);
+        \fwrite($outputFP, $nonce, 24);
+
+        $b2mac = SodiumCompat::crypto_generichash_init(
+            $this->getIntegrityKey($key)->getRawKey(),
+            self::MAC_SIZE
+        );
+        SodiumCompat::crypto_generichash_update($b2mac, (string) (static::MAGIC_HEADER) . $salt . $nonce);
+
+        $ctr = 1;
+        $ctrIncrease = ($chunkSize + 63) >> 6;
+        $len = 0;
+        do {
+            $plaintext = \fread($inputFP, $chunkSize);
+            $len += Binary::safeStrlen($plaintext);
+            $ciphertext = ChaCha20::ietfStreamXorIc(
+                $plaintext,
+                $nonceLast,
+                $subkey,
+                SodiumUtil::store64_le($ctr)
+            );
+            \fwrite($outputFP, $ciphertext);
+            SodiumCompat::crypto_generichash_update($b2mac, $ciphertext);
+            $ctr += $ctrIncrease;
+        } while (!\feof($inputFP));
+        $end = \ftell($outputFP);
+
+        SodiumCompat::crypto_generichash_update($b2mac, SodiumUtil::store64_le($adlen));
+        SodiumCompat::crypto_generichash_update($b2mac, SodiumUtil::store64_le($len));
+        $authTag = SodiumCompat::crypto_generichash_final($b2mac, self::MAC_SIZE);
+
+        // Write the Poly1305 auth tag at the beginning of the file
+        \fseek($outputFP, 5, SEEK_SET);
+        \fwrite($outputFP, $authTag, 32);
+        \fseek($outputFP, $end, SEEK_SET);
+        \rewind($outputFP);
+        return true;
+    }
+
+    /**
+     * @return int
+     */
+    public function getFileEncryptionSaltOffset()
+    {
+        return 37;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPrefix()
+    {
+        return (string) static::MAGIC_HEADER;
+    }
+}

--- a/src/Backend/BoringCrypto.php
+++ b/src/Backend/BoringCrypto.php
@@ -4,6 +4,7 @@ namespace ParagonIE\CipherSweet\Backend;
 use ParagonIE\CipherSweet\Backend\Key\SymmetricKey;
 use ParagonIE\CipherSweet\Constants;
 use ParagonIE\CipherSweet\Contract\BackendInterface;
+use ParagonIE\CipherSweet\Contract\MultiTenantSafeBackendInterface;
 use ParagonIE\CipherSweet\Exception\CryptoOperationException;
 use ParagonIE\CipherSweet\Exception\InvalidCiphertextException;
 use ParagonIE\CipherSweet\Util;
@@ -13,7 +14,6 @@ use ParagonIE\ConstantTime\Binary;
 use ParagonIE_Sodium_Compat as SodiumCompat;
 use ParagonIE\Sodium\Core\ChaCha20;
 use ParagonIE\Sodium\Core\HChaCha20;
-use ParagonIE\Sodium\Core\XChaCha20;
 use ParagonIE_Sodium_Core_Util as SodiumUtil;
 
 /**
@@ -23,7 +23,7 @@ use ParagonIE_Sodium_Core_Util as SodiumUtil;
  *
  * @package ParagonIE\CipherSweet\Backend
  */
-class BoringCrypto implements BackendInterface
+class BoringCrypto implements BackendInterface, MultiTenantSafeBackendInterface
 {
     const MAGIC_HEADER = "brng:";
     const NONCE_SIZE = 24;
@@ -72,7 +72,7 @@ class BoringCrypto implements BackendInterface
         } catch (\Exception $ex) {
             throw new CryptoOperationException('CSPRNG failure', 0, $ex);
         }
-        $ciphertext = XChaCha20::streamXorIc(
+        $ciphertext = \sodium_crypto_stream_xchacha20_xor(
             $plaintext,
             $nonce,
             $this->getEncryptionKey($key)->getRawKey()
@@ -128,7 +128,7 @@ class BoringCrypto implements BackendInterface
             throw new \SodiumException("Invalid ciphertext");
         }
 
-        return XChaCha20::streamXorIc(
+        return \sodium_crypto_stream_xchacha20_xor(
             $encrypted,
             $nonce,
             $this->getEncryptionKey($key)->getRawKey()

--- a/src/Backend/FIPSCrypto.php
+++ b/src/Backend/FIPSCrypto.php
@@ -4,6 +4,7 @@ namespace ParagonIE\CipherSweet\Backend;
 use ParagonIE\CipherSweet\Constants;
 use ParagonIE\CipherSweet\Contract\BackendInterface;
 use ParagonIE\CipherSweet\Backend\Key\SymmetricKey;
+use ParagonIE\CipherSweet\Contract\MultiTenantSafeBackendInterface;
 use ParagonIE\CipherSweet\Exception\CryptoOperationException;
 use ParagonIE\CipherSweet\Exception\InvalidCiphertextException;
 use ParagonIE\CipherSweet\Util;
@@ -26,7 +27,7 @@ use ParagonIE_Sodium_Core_Util as SodiumUtil;
  *
  * @package ParagonIE\CipherSweet\Backend
  */
-class FIPSCrypto implements BackendInterface
+class FIPSCrypto implements BackendInterface, MultiTenantSafeBackendInterface
 {
     const MAGIC_HEADER = "fips:";
     const MAC_SIZE = 48;

--- a/src/CipherSweet.php
+++ b/src/CipherSweet.php
@@ -161,15 +161,16 @@ final class CipherSweet
 
     /**
      * @param array $row
+     * @param string $tableName
      * @return string
      * @throws CipherSweetException
      */
-    public function getTenantFromRow(array $row)
+    public function getTenantFromRow(array $row, $tableName = '')
     {
         /** @param MultiTenantAwareProviderInterface $kp */
         if ($this->keyProvider instanceof MultiTenantAwareProviderInterface) {
             $kp = $this->keyProvider;
-            return $kp->getTenantFromRow($row);
+            return $kp->getTenantFromRow($row, $tableName);
         }
         throw new CipherSweetException('Your Key Provider is not multi-tenant aware');
     }
@@ -191,14 +192,15 @@ final class CipherSweet
 
     /**
      * @param array $row
+     * @param string $tableName
      * @return array
      * @throws CipherSweetException
      */
-    public function injectTenantMetadata(array $row)
+    public function injectTenantMetadata(array $row, $tableName = '')
     {
         if ($this->keyProvider instanceof MultiTenantAwareProviderInterface) {
             $kp = $this->keyProvider;
-            return $kp->injectTenantMetadata($row);
+            return $kp->injectTenantMetadata($row, $tableName);
         }
         throw new CipherSweetException('Multi-tenant is not supported');
     }

--- a/src/CipherSweet.php
+++ b/src/CipherSweet.php
@@ -1,10 +1,13 @@
 <?php
 namespace ParagonIE\CipherSweet;
 
+use ParagonIE\CipherSweet\Backend\BoringCrypto;
 use ParagonIE\CipherSweet\Backend\Key\SymmetricKey;
-use ParagonIE\CipherSweet\Backend\ModernCrypto;
 use ParagonIE\CipherSweet\Contract\BackendInterface;
 use ParagonIE\CipherSweet\Contract\KeyProviderInterface;
+use ParagonIE\CipherSweet\Contract\MultiTenantAwareProviderInterface;
+use ParagonIE\CipherSweet\Contract\MultiTenantSafeBackendInterface;
+use ParagonIE\CipherSweet\Exception\CipherSweetException;
 use ParagonIE\CipherSweet\Exception\CryptoOperationException;
 
 /**
@@ -34,7 +37,7 @@ final class CipherSweet
         BackendInterface $backend = null
     ) {
         $this->keyProvider = $keyProvider;
-        $this->backend = $backend ?: new ModernCrypto;
+        $this->backend = $backend ?: new BoringCrypto();
     }
 
     /**
@@ -98,10 +101,22 @@ final class CipherSweet
      * @param string $fieldName
      *
      * @return SymmetricKey
+     *
+     * @throws CipherSweetException
      * @throws CryptoOperationException
      */
     public function getFieldSymmetricKey($tableName, $fieldName)
     {
+        if ($this->isMultiTenantSupported()) {
+            return new SymmetricKey(
+                Util::HKDF(
+                    $this->getKeyProviderForActiveTenant()->getSymmetricKey(),
+                    $tableName,
+                    Constants::DS_FENC . $fieldName
+                )
+            );
+        }
+
         return new SymmetricKey(
             Util::HKDF(
                 $this->keyProvider->getSymmetricKey(),
@@ -109,5 +124,84 @@ final class CipherSweet
                 Constants::DS_FENC . $fieldName
             )
         );
+    }
+
+    /**
+     * Get the key provider for a given tenant
+     *
+     * @return KeyProviderInterface
+     * @throws CipherSweetException
+     */
+    public function getKeyProviderForActiveTenant()
+    {
+        if (!($this->keyProvider instanceof MultiTenantAwareProviderInterface)) {
+            throw new CipherSweetException('Your Key Provider is not multi-tenant aware');
+        }
+        /** @param MultiTenantAwareProviderInterface $kp */
+        $kp = $this->keyProvider;
+        return $kp->getActiveTenant();
+    }
+
+    /**
+     * Get the key provider for a given tenant
+     *
+     * @param array-key $name
+     * @return KeyProviderInterface
+     * @throws CipherSweetException
+     */
+    public function getKeyProviderForTenant($name)
+    {
+        if (!($this->keyProvider instanceof MultiTenantAwareProviderInterface)) {
+            throw new CipherSweetException('Your Key Provider is not multi-tenant aware');
+        }
+        /** @param MultiTenantAwareProviderInterface $kp */
+        $kp = $this->keyProvider;
+        return $kp->getTenant($name);
+    }
+
+    /**
+     * @param array $row
+     * @return KeyProviderInterface|string
+     * @throws CipherSweetException
+     */
+    public function getTenantFromRow(array $row)
+    {
+        /** @param MultiTenantAwareProviderInterface $kp */
+        if ($this->keyProvider instanceof MultiTenantAwareProviderInterface) {
+            $kp = $this->keyProvider;
+            return $kp->getTenantFromRow($row);
+        }
+        throw new CipherSweetException('Your Key Provider is not multi-tenant aware');
+    }
+
+    /**
+     * @param string $name
+     * @return void
+     * @throws CipherSweetException
+     */
+    public function setActiveTenant($name)
+    {
+        /** @param MultiTenantAwareProviderInterface $kp */
+        if ($this->keyProvider instanceof MultiTenantAwareProviderInterface) {
+            $this->keyProvider->setActiveTenant($name);
+        }
+        throw new CipherSweetException('Your Key Provider is not multi-tenant aware');
+    }
+
+    /**
+     * @return bool
+     */
+    public function isMultiTenantSupported()
+    {
+        if (!($this->backend instanceof MultiTenantSafeBackendInterface)) {
+            // Backend doesn't provide the cryptographic properties we need.
+            return false;
+        }
+
+        if (!($this->keyProvider instanceof MultiTenantAwareProviderInterface)) {
+            // KeyProvider doesn't understand the concept of multiple tenants.
+            return false;
+        }
+        return true;
     }
 }

--- a/src/CipherSweet.php
+++ b/src/CipherSweet.php
@@ -184,8 +184,23 @@ final class CipherSweet
         /** @param MultiTenantAwareProviderInterface $kp */
         if ($this->keyProvider instanceof MultiTenantAwareProviderInterface) {
             $this->keyProvider->setActiveTenant($name);
+            return;
         }
         throw new CipherSweetException('Your Key Provider is not multi-tenant aware');
+    }
+
+    /**
+     * @param array $row
+     * @return array
+     * @throws CipherSweetException
+     */
+    public function injectTenantMetadata(array $row)
+    {
+        if ($this->keyProvider instanceof MultiTenantAwareProviderInterface) {
+            $kp = $this->keyProvider;
+            return $kp->injectTenantMetadata($row);
+        }
+        throw new CipherSweetException('Multi-tenant is not supported');
     }
 
     /**

--- a/src/CipherSweet.php
+++ b/src/CipherSweet.php
@@ -161,7 +161,7 @@ final class CipherSweet
 
     /**
      * @param array $row
-     * @return KeyProviderInterface|string
+     * @return string
      * @throws CipherSweetException
      */
     public function getTenantFromRow(array $row)

--- a/src/Contract/MultiTenantAwareProviderInterface.php
+++ b/src/Contract/MultiTenantAwareProviderInterface.php
@@ -1,0 +1,31 @@
+<?php
+namespace ParagonIE\CipherSweet\Contract;
+
+use ParagonIE\CipherSweet\Exception\CipherSweetException;
+
+/**
+ * Interface MultiTenantAwareProviderInterface
+ * @package ParagonIE\CipherSweet\Contract
+ */
+interface MultiTenantAwareProviderInterface
+{
+
+    /**
+     * @return KeyProviderInterface
+     * @throws CipherSweetException
+     */
+    public function getActiveTenant();
+
+    /**
+     * @param array-key $name
+     * @return KeyProviderInterface
+     * @throws CipherSweetException
+     */
+    public function getTenant($name);
+
+    /**
+     * @param array-key $index
+     * @return self
+     */
+    public function setActiveTenant($index);
+}

--- a/src/Contract/MultiTenantAwareProviderInterface.php
+++ b/src/Contract/MultiTenantAwareProviderInterface.php
@@ -35,15 +35,17 @@ interface MultiTenantAwareProviderInterface
      * Given a row of data, determine which tenant should be selected.
      *
      * @param array $row
+     * @param string $tableName
      * @return string
      *
      * @throws CipherSweetException
      */
-    public function getTenantFromRow(array $row);
+    public function getTenantFromRow(array $row, $tableName);
 
     /**
      * @param array $row
+     * @param string $tableName
      * @return array
      */
-    public function injectTenantMetadata(array $row);
+    public function injectTenantMetadata(array $row, $tableName);
 }

--- a/src/Contract/MultiTenantAwareProviderInterface.php
+++ b/src/Contract/MultiTenantAwareProviderInterface.php
@@ -28,4 +28,22 @@ interface MultiTenantAwareProviderInterface
      * @return self
      */
     public function setActiveTenant($index);
+
+    /**
+     * OVERRIDE THIS in your own class!
+     *
+     * Given a row of data, determine which tenant should be selected.
+     *
+     * @param array $row
+     * @return string
+     *
+     * @throws CipherSweetException
+     */
+    public function getTenantFromRow(array $row);
+
+    /**
+     * @param array $row
+     * @return array
+     */
+    public function injectTenantMetadata(array $row);
 }

--- a/src/Contract/MultiTenantSafeBackendInterface.php
+++ b/src/Contract/MultiTenantSafeBackendInterface.php
@@ -1,0 +1,11 @@
+<?php
+namespace ParagonIE\CipherSweet\Contract;
+
+/**
+ * Interface MultiTenantSafeBackendInterface
+ * @package ParagonIE\CipherSweet\Contract
+ */
+interface MultiTenantSafeBackendInterface
+{
+
+}

--- a/src/EncryptedField.php
+++ b/src/EncryptedField.php
@@ -74,6 +74,25 @@ class EncryptedField
     }
 
     /**
+     * @param array-key $tenantIndex
+     * @return self
+     * @throws CipherSweetException
+     * @throws CryptoOperationException
+     */
+    public function setActiveTenant($tenantIndex)
+    {
+        if (!$this->engine->isMultiTenantSupported()) {
+            throw new CipherSweetException('This is only available for multi-tenant-aware engines/providers.');
+        }
+        $this->engine->setActiveTenant($tenantIndex);
+        $this->key = $this->engine->getFieldSymmetricKey(
+            $this->tableName,
+            $this->fieldName
+        );
+        return $this;
+    }
+
+    /**
      * Encrypt a value and calculate all of its blind indices in one go.
      *
      * @param string $plaintext

--- a/src/EncryptedField.php
+++ b/src/EncryptedField.php
@@ -74,7 +74,11 @@ class EncryptedField
     }
 
     /**
-     * @param array-key $tenantIndex
+     * Only usable in multi-tenant setups.
+     *
+     * Sets the active tenant and re-derives the encryption key for this field.
+     *
+     * @param string $tenantIndex
      * @return self
      * @throws CipherSweetException
      * @throws CryptoOperationException

--- a/src/EncryptedField.php
+++ b/src/EncryptedField.php
@@ -5,6 +5,7 @@ use ParagonIE\CipherSweet\Backend\Key\SymmetricKey;
 use ParagonIE\CipherSweet\Contract\BackendInterface;
 use ParagonIE\CipherSweet\Exception\BlindIndexNameCollisionException;
 use ParagonIE\CipherSweet\Exception\BlindIndexNotFoundException;
+use ParagonIE\CipherSweet\Exception\CipherSweetException;
 use ParagonIE\CipherSweet\Exception\CryptoOperationException;
 use ParagonIE\ConstantTime\Hex;
 use SodiumException;
@@ -54,6 +55,7 @@ class EncryptedField
      * @param bool $useTypedIndexes
      *
      * @throws CryptoOperationException
+     * @throws CipherSweetException
      */
     public function __construct(
         CipherSweet $engine,
@@ -96,6 +98,10 @@ class EncryptedField
      * @param string $plaintext
      * @param string $aad       Additional authenticated data
      * @return string
+     *
+     * @throws CryptoOperationException
+     * @throws Exception\CipherSweetException
+     * @throws SodiumException
      */
     public function encryptValue($plaintext, $aad = '')
     {
@@ -115,6 +121,10 @@ class EncryptedField
      * @param string $ciphertext
      * @param string $aad       Additional authenticated data
      * @return string
+     *
+     * @throws Exception\CipherSweetException
+     * @throws Exception\InvalidCiphertextException
+     * @throws SodiumException
      */
     public function decryptValue($ciphertext, $aad = '')
     {

--- a/src/EncryptedRow.php
+++ b/src/EncryptedRow.php
@@ -3,7 +3,6 @@ namespace ParagonIE\CipherSweet;
 
 use ParagonIE\CipherSweet\Backend\Key\SymmetricKey;
 use ParagonIE\CipherSweet\Contract\BackendInterface;
-use ParagonIE\CipherSweet\Contract\MultiTenantAwareProviderInterface;
 use ParagonIE\CipherSweet\Exception\ArrayKeyException;
 use ParagonIE\CipherSweet\Exception\BlindIndexNotFoundException;
 use ParagonIE\CipherSweet\Exception\CipherSweetException;

--- a/src/EncryptedRow.php
+++ b/src/EncryptedRow.php
@@ -320,7 +320,7 @@ class EncryptedRow
         $return = $row;
         $backend = $this->engine->getBackend();
         if ($this->engine->isMultiTenantSupported()) {
-            $tenant = $this->engine->getTenantFromRow($row);
+            $tenant = $this->engine->getTenantFromRow($row, $this->tableName);
             $this->engine->setActiveTenant($tenant);
         }
         foreach ($this->fieldsToEncrypt as $field => $type) {
@@ -394,7 +394,7 @@ class EncryptedRow
         }
         /** @var array<string, string> $return */
         if ($this->engine->isMultiTenantSupported()) {
-            return $this->engine->injectTenantMetadata($return);
+            return $this->engine->injectTenantMetadata($return, $this->tableName);
         }
         return $return;
     }
@@ -413,7 +413,8 @@ class EncryptedRow
      * @return array{0: array<string, string>, 1: array<string, array<string, string>|string>}
      *
      * @throws ArrayKeyException
-     * @throws Exception\CryptoOperationException
+     * @throws CipherSweetException
+     * @throws CryptoOperationException
      * @throws SodiumException
      */
     public function prepareRowForStorage(array $row)

--- a/src/EncryptedRow.php
+++ b/src/EncryptedRow.php
@@ -316,6 +316,10 @@ class EncryptedRow
         $return = $row;
         $backend = $this->engine->getBackend();
         foreach ($this->fieldsToEncrypt as $field => $type) {
+            if ($this->engine->isMultiTenantSupported()) {
+                $tenant = $this->engine->getTenantFromRow($row);
+                $this->engine->setActiveTenant($tenant);
+            }
             $key = $this->engine->getFieldSymmetricKey(
                 $this->tableName,
                 $field
@@ -365,6 +369,10 @@ class EncryptedRow
             }
             /** @var string $plaintext */
             $plaintext = $this->convertToString($row[$field], $type);
+            if ($this->engine->isMultiTenantSupported()) {
+                $tenant = $this->engine->getTenantFromRow($row);
+                $this->engine->setActiveTenant($tenant);
+            }
             $key = $this->engine->getFieldSymmetricKey(
                 $this->tableName,
                 $field

--- a/src/EncryptedRow.php
+++ b/src/EncryptedRow.php
@@ -8,6 +8,7 @@ use ParagonIE\CipherSweet\Exception\ArrayKeyException;
 use ParagonIE\CipherSweet\Exception\BlindIndexNotFoundException;
 use ParagonIE\CipherSweet\Exception\CipherSweetException;
 use ParagonIE\CipherSweet\Exception\CryptoOperationException;
+use ParagonIE\CipherSweet\Exception\InvalidCiphertextException;
 use ParagonIE\ConstantTime\Hex;
 use SodiumException;
 
@@ -310,7 +311,9 @@ class EncryptedRow
      *
      * @param array<string, string> $row
      * @return array<string, string|int|float|bool|null>
-     * @throws Exception\CryptoOperationException
+     * @throws CipherSweetException
+     * @throws CryptoOperationException
+     * @throws InvalidCiphertextException
      * @throws SodiumException
      */
     public function decryptRow(array $row)

--- a/src/KeyProvider/MultiTenantProvider.php
+++ b/src/KeyProvider/MultiTenantProvider.php
@@ -1,7 +1,6 @@
 <?php
 namespace ParagonIE\CipherSweet\KeyProvider;
 
-
 use ParagonIE\CipherSweet\Backend\Key\SymmetricKey;
 use ParagonIE\CipherSweet\Contract\KeyProviderInterface;
 use ParagonIE\CipherSweet\Contract\MultiTenantAwareProviderInterface;
@@ -101,11 +100,12 @@ class MultiTenantProvider implements KeyProviderInterface, MultiTenantAwareProvi
      * Given a row of data, determine which tenant should be selected.
      *
      * @param array $row
+     * @param string $tableName
      * @return string
      *
      * @throws CipherSweetException
      */
-    public function getTenantFromRow(array $row)
+    public function getTenantFromRow(array $row, $tableName)
     {
         if (!$this->active) {
             throw new CipherSweetException('This is not implemented. Please override in a child class.');
@@ -117,9 +117,10 @@ class MultiTenantProvider implements KeyProviderInterface, MultiTenantAwareProvi
      * OVERRIDE THIS in your own class!
      *
      * @param array $row
+     * @param string $tableName
      * @return array
      */
-    public function injectTenantMetadata(array $row)
+    public function injectTenantMetadata(array $row, $tableName)
     {
         return $row;
     }

--- a/src/KeyProvider/MultiTenantProvider.php
+++ b/src/KeyProvider/MultiTenantProvider.php
@@ -1,0 +1,114 @@
+<?php
+namespace ParagonIE\CipherSweet\KeyProvider;
+
+
+use ParagonIE\CipherSweet\Backend\Key\SymmetricKey;
+use ParagonIE\CipherSweet\Contract\KeyProviderInterface;
+use ParagonIE\CipherSweet\Contract\MultiTenantAwareProviderInterface;
+use ParagonIE\CipherSweet\Exception\CipherSweetException;
+
+/**
+ * Class MultiTenantProvider
+ * @package ParagonIE\CipherSweet\KeyProvider
+ */
+class MultiTenantProvider implements KeyProviderInterface, MultiTenantAwareProviderInterface
+{
+    /** @var array<array-key, KeyProviderInterface> $tenants */
+    private $tenants = [];
+
+    /** @var array-key|null $active */
+    private $active;
+
+    /**
+     * MultiTenantProvider constructor.
+     *
+     * @param array<array-key, KeyProviderInterface> $keyProviders
+     * @param array-key|null $active
+     */
+    public function __construct(array $keyProviders, $active = null)
+    {
+        foreach ($keyProviders as $name => $keyProvider) {
+            $this->tenants[$name] = $keyProviders;
+        }
+        $this->active = $active;
+    }
+
+    /**
+     * @param array-key $index
+     * @param KeyProviderInterface $provider
+     * @return self
+     */
+    public function addTenant($index, KeyProviderInterface $provider)
+    {
+        $this->tenants[$index] = $provider;
+        return $this;
+    }
+
+    /**
+     * @param array-key $index
+     * @return self
+     */
+    public function setActiveTenant($index)
+    {
+        $this->active = $index;
+        return $this;
+    }
+
+    /**
+     * @param array-key $name
+     * @return KeyProviderInterface
+     * @throws CipherSweetException
+     */
+    public function getTenant($name)
+    {
+        if (!\array_key_exists($name, $this->tenants)) {
+            throw new CipherSweetException('Tenant does not exist');
+        }
+        return $this->tenants[$this->active];
+    }
+
+    /**
+     * @return KeyProviderInterface
+     * @throws CipherSweetException
+     */
+    public function getActiveTenant()
+    {
+        if (\is_null($this->active)) {
+            throw new CipherSweetException('Active tenant not set');
+        }
+        if (!\array_key_exists($this->active, $this->tenants)) {
+            throw new CipherSweetException('Tenant does not exist');
+        }
+        return $this->tenants[$this->active];
+    }
+
+    /**
+     * @return SymmetricKey
+     * @throws CipherSweetException
+     */
+    public function getSymmetricKey()
+    {
+        if (\is_null($this->active)) {
+            throw new CipherSweetException('Active tenant not set');
+        }
+        return $this->getActiveTenant()->getSymmetricKey();
+    }
+
+    /**
+     * OVERRIDE THIS in your own class!
+     *
+     * Given a row of data, determine which tenant should be selected.
+     *
+     * @param array $row
+     * @return string
+     *
+     * @throws CipherSweetException
+     */
+    public function getTenantFromRow(array $row)
+    {
+        if (!$this->active) {
+            throw new CipherSweetException('This is not implemented. Please override in a child class.');
+        }
+        return $this->active;
+    }
+}

--- a/src/KeyProvider/MultiTenantProvider.php
+++ b/src/KeyProvider/MultiTenantProvider.php
@@ -14,10 +14,10 @@ use ParagonIE\CipherSweet\Exception\CipherSweetException;
 class MultiTenantProvider implements KeyProviderInterface, MultiTenantAwareProviderInterface
 {
     /** @var array<array-key, KeyProviderInterface> $tenants */
-    private $tenants = [];
+    protected $tenants = [];
 
     /** @var array-key|null $active */
-    private $active;
+    protected $active;
 
     /**
      * MultiTenantProvider constructor.
@@ -28,7 +28,7 @@ class MultiTenantProvider implements KeyProviderInterface, MultiTenantAwareProvi
     public function __construct(array $keyProviders, $active = null)
     {
         foreach ($keyProviders as $name => $keyProvider) {
-            $this->tenants[$name] = $keyProviders;
+            $this->tenants[$name] = $keyProvider;
         }
         $this->active = $active;
     }
@@ -110,5 +110,16 @@ class MultiTenantProvider implements KeyProviderInterface, MultiTenantAwareProvi
             throw new CipherSweetException('This is not implemented. Please override in a child class.');
         }
         return $this->active;
+    }
+
+    /**
+     * OVERRIDE THIS in your own class!
+     *
+     * @param array $row
+     * @return array
+     */
+    public function injectTenantMetadata(array $row)
+    {
+        return $row;
     }
 }

--- a/src/KeyProvider/MultiTenantProvider.php
+++ b/src/KeyProvider/MultiTenantProvider.php
@@ -58,6 +58,7 @@ class MultiTenantProvider implements KeyProviderInterface, MultiTenantAwareProvi
      * @param array-key $name
      * @return KeyProviderInterface
      * @throws CipherSweetException
+     * @psalm-suppress PossiblyNullArrayOffset
      */
     public function getTenant($name)
     {

--- a/tests/Backend/BoringCryptoTest.php
+++ b/tests/Backend/BoringCryptoTest.php
@@ -1,0 +1,28 @@
+<?php
+namespace ParagonIE\CipherSweet\Tests\Backend;
+
+use ParagonIE\CipherSweet\Backend\BoringCrypto;
+use ParagonIE\CipherSweet\KeyProvider\StringProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class BoringCryptoTest
+ * @package ParagonIE\CipherSweet\Tests
+ */
+class BoringCryptoTest extends TestCase
+{
+    /**
+     * @throws \Exception
+     */
+    public function testEncrypt()
+    {
+        $nacl = new BoringCrypto();
+        $keyProvider = new StringProvider(random_bytes(32));
+
+        $message = 'This is just a test message';
+        $cipher = $nacl->encrypt($message, $keyProvider->getSymmetricKey());
+        $decrypted = $nacl->decrypt($cipher, $keyProvider->getSymmetricKey());
+
+        $this->assertSame($message, $decrypted);
+    }
+}

--- a/tests/CreatesEngines.php
+++ b/tests/CreatesEngines.php
@@ -2,6 +2,7 @@
 
 namespace ParagonIE\CipherSweet\Tests;
 
+use ParagonIE\CipherSweet\Backend\BoringCrypto;
 use ParagonIE\CipherSweet\Backend\FIPSCrypto;
 use ParagonIE\CipherSweet\Backend\ModernCrypto;
 use ParagonIE\CipherSweet\CipherSweet;
@@ -33,6 +34,19 @@ trait CreatesEngines
         return new CipherSweet(
             new StringProvider($key ? Hex::decode($key) : random_bytes(32)),
             new ModernCrypto
+        );
+    }
+
+    /**
+     * @param string|null $key
+     * @return CipherSweet
+     * @throws \ParagonIE\CipherSweet\Exception\CryptoOperationException
+     */
+    final protected function createBoringEngine($key = null)
+    {
+        return new CipherSweet(
+            new StringProvider($key ? Hex::decode($key) : random_bytes(32)),
+            new BoringCrypto
         );
     }
 }

--- a/tests/EncryptedFieldTest.php
+++ b/tests/EncryptedFieldTest.php
@@ -44,10 +44,11 @@ class EncryptedFieldTest extends TestCase
     protected $naclRandom;
 
     /**
+     * @before
      * @throws ArrayKeyException
      * @throws CryptoOperationException
      */
-    public function setUp()
+    public function before()
     {
         $this->fipsEngine = $this->createFipsEngine('4e1c44f87b4cdf21808762970b356891db180a9dd9850e7baf2a79ff3ab8a2fc');
         $this->naclEngine = $this->createModernEngine('4e1c44f87b4cdf21808762970b356891db180a9dd9850e7baf2a79ff3ab8a2fc');

--- a/tests/EncryptedFileTest.php
+++ b/tests/EncryptedFileTest.php
@@ -26,9 +26,10 @@ class EncryptedFileTest extends TestCase
     private $nacl;
 
     /**
+     * @before
      * @throws CryptoOperationException
      */
-    public function setUp()
+    public function before()
     {
         $this->fips = new EncryptedFile(
             $this->createFipsEngine('4e1c44f87b4cdf21808762970b356891db180a9dd9850e7baf2a79ff3ab8a2fc')
@@ -43,7 +44,10 @@ class EncryptedFileTest extends TestCase
         );
     }
 
-    public function tearDown()
+    /**
+     * @afterClass
+     */
+    public function afterClass()
     {
         if (file_exists(__DIR__ . '/scratch.txt')) {
             unlink(__DIR__ . '/scratch.txt');

--- a/tests/EncryptedMultiRowsTest.php
+++ b/tests/EncryptedMultiRowsTest.php
@@ -37,9 +37,10 @@ class EncryptedMultiRowsTest extends TestCase
     protected $naclRandom;
 
     /**
+     * @before
      * @throws \Exception
      */
-    public function setUp()
+    public function before()
     {
         $this->fipsEngine = $this->createFipsEngine('4e1c44f87b4cdf21808762970b356891db180a9dd9850e7baf2a79ff3ab8a2fc');
         $this->naclEngine = $this->createModernEngine('4e1c44f87b4cdf21808762970b356891db180a9dd9850e7baf2a79ff3ab8a2fc');

--- a/tests/EncryptedRowTest.php
+++ b/tests/EncryptedRowTest.php
@@ -44,9 +44,10 @@ class EncryptedRowTest extends TestCase
     protected $naclRandom;
 
     /**
+     * @before
      * @throws CryptoOperationException
      */
-    public function setUp()
+    public function before()
     {
         $this->fipsEngine = $this->createFipsEngine('4e1c44f87b4cdf21808762970b356891db180a9dd9850e7baf2a79ff3ab8a2fc');
         $this->naclEngine = $this->createModernEngine('4e1c44f87b4cdf21808762970b356891db180a9dd9850e7baf2a79ff3ab8a2fc');

--- a/tests/KeyProvider/FileProviderTest.php
+++ b/tests/KeyProvider/FileProviderTest.php
@@ -18,9 +18,10 @@ class FileProviderTest extends TestCase
     private $prefix;
 
     /**
+     * @before
      * @throws \SodiumException
      */
-    public function setUp()
+    public function before()
     {
         $this->prefix = Base32::encodeUnpadded(random_bytes(16));
 
@@ -31,7 +32,10 @@ class FileProviderTest extends TestCase
         );
     }
 
-    public function tearDown()
+    /**
+     * @afterClass
+     */
+    public function afterClass()
     {
         \unlink(__DIR__ . '/files/' . $this->prefix . '.symmetric');
         parent::tearDown();

--- a/tests/MultiTenant/MultiTenantTest.php
+++ b/tests/MultiTenant/MultiTenantTest.php
@@ -1,0 +1,104 @@
+<?php
+namespace ParagonIE\CipherSweet\Tests\MultiTenant;
+
+use ParagonIE\CipherSweet\Backend\BoringCrypto;
+use ParagonIE\CipherSweet\Backend\FIPSCrypto;
+use ParagonIE\CipherSweet\CipherSweet;
+use ParagonIE\CipherSweet\CompoundIndex;
+use ParagonIE\CipherSweet\EncryptedRow;
+use ParagonIE\CipherSweet\Exception\CipherSweetException;
+use ParagonIE\CipherSweet\KeyProvider\StringProvider;
+use ParagonIE\CipherSweet\Transformation\LastFourDigits;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class MultiTenantTest
+ * @package ParagonIE\CipherSweet\Tests\MultiTenant
+ */
+class MultiTenantTest extends TestCase
+{
+    /** @var CipherSweet $csBoring */
+    private $csBoring;
+    /** @var CipherSweet $csFips */
+    private $csFips;
+
+    /**
+     * @before
+     */
+    public function before()
+    {
+        $provider = new TestMultiTenantKeyProvider([
+            'foo' => new StringProvider(random_bytes(32)),
+            'bar' => new StringProvider(random_bytes(32)),
+            'baz' => new StringProvider(random_bytes(32)),
+        ]);
+        $provider->setActiveTenant('foo');
+        $this->csBoring = new CipherSweet($provider, new BoringCrypto());
+        $this->csFips = new CipherSweet($provider, new FIPSCrypto());
+    }
+
+    protected function getERClass(CipherSweet $cs)
+    {
+        $ER = new EncryptedRow($cs, 'customer');
+        $ER->addTextField('email', 'customerid');
+        $ER->addTextField('ssn', 'customerid');
+        $ER->addBooleanField('active', 'customerid');
+        $ER->addCompoundIndex(
+            (new CompoundIndex('customer_ssnlast4_active', ['ssn', 'active'], 15, true))
+                ->addTransform('ssn', new LastFourDigits())
+        );
+        return $ER;
+    }
+
+    /**
+     * Test that the EncryptedRow feature correctly interacts with multi-tenant data stores.
+     *
+     * @throws CipherSweetException
+     * @throws \ParagonIE\CipherSweet\Exception\ArrayKeyException
+     * @throws \ParagonIE\CipherSweet\Exception\CryptoOperationException
+     * @throws \SodiumException
+     */
+    public function testEncryptRow()
+    {
+        foreach ([$this->csBoring, $this->csFips] as $cs) {
+            $ER = $this->getERClass($cs);
+
+            // We encrypt this on behalf of one tenant:
+            $cs->setActiveTenant('foo');
+            $row1 = $ER->encryptRow([
+                'customerid' => 1,
+                'email' => 'ciphersweet@paragonie.com',
+                'ssn' => '123-45-6789',
+                'active' => true
+            ]);
+            $this->assertSame('foo', $row1['tenant']);
+            $plain1 = $ER->decryptRow($row1);
+            $this->assertSame('ciphersweet@paragonie.com', $plain1['email']);
+
+            // We encrypt this on behalf of another tenant:
+            $cs->setActiveTenant('bar');
+            $row2 = $ER->encryptRow([
+                'customerid' => 2,
+                'email' => 'security@paragonie.com',
+                'ssn' => '987-65-4321',
+                'active' => true
+            ]);
+            $this->assertSame('bar', $row2['tenant']);
+            $plain2 = $ER->decryptRow($row2);
+            $this->assertSame('security@paragonie.com', $plain2['email']);
+
+            // Make a copy, switch the tenant identifier
+            $row3 = $row2;
+            $row3['tenant'] = 'foo';
+            $decryptFailed = false;
+            try {
+                $ER->decryptRow($row3);
+            } catch (\SodiumException $ex) {
+                $decryptFailed = true;
+            } catch (CipherSweetException $ex) {
+                $decryptFailed = true;
+            }
+            $this->assertTrue($decryptFailed, 'Swapping out tenant identifiers should fail decryption');
+        }
+    }
+}

--- a/tests/MultiTenant/README.md
+++ b/tests/MultiTenant/README.md
@@ -4,4 +4,4 @@ The tests contained in this directory are for testing CipherSweet
 within the context of multi-tenant data storage.
 
 What this means is that you have *multiple encryption keys* used,
-but each row will only be encrypted by key.
+but each row will only be encrypted by one key.

--- a/tests/MultiTenant/README.md
+++ b/tests/MultiTenant/README.md
@@ -1,0 +1,7 @@
+# Multi-Tenant Tests
+
+The tests contained in this directory are for testing CipherSweet
+within the context of multi-tenant data storage.
+
+What this means is that you have *multiple encryption keys* used,
+but each row will only be encrypted by key.

--- a/tests/MultiTenant/TestMultiTenantKeyProvider.php
+++ b/tests/MultiTenant/TestMultiTenantKeyProvider.php
@@ -1,0 +1,50 @@
+<?php
+namespace ParagonIE\CipherSweet\Tests\MultiTenant;
+
+use ParagonIE\CipherSweet\Contract\KeyProviderInterface;
+use ParagonIE\CipherSweet\Contract\MultiTenantAwareProviderInterface;
+use ParagonIE\CipherSweet\Exception\CipherSweetException;
+use ParagonIE\CipherSweet\KeyProvider\MultiTenantProvider;
+
+/**
+ * Class TestMultiTenantKeyProvider
+ * @package ParagonIE\CipherSweet\Tests\MultiTenant
+ */
+class TestMultiTenantKeyProvider extends MultiTenantProvider
+{
+    public function __construct(array $keyProviders, $active = null)
+    {
+        parent::__construct($keyProviders, $active);
+    }
+
+    /**
+     * Given a row of data, determine which tenant should be selected.
+     *
+     * @param array $row
+     * @return string
+     *
+     * @throws CipherSweetException
+     */
+    public function getTenantFromRow(array $row)
+    {
+        switch ($row['tenant']) {
+            case 'foo':
+            case 'bar':
+            case 'baz':
+                return $row['tenant'];
+            default:
+                return parent::getTenantFromRow($row);
+        }
+    }
+
+    /**
+     * @param array $row
+     * @return array
+     * @throws CipherSweetException
+     */
+    public function injectTenantMetadata(array $row)
+    {
+        $row['tenant'] = $this->active;
+        return $row;
+    }
+}

--- a/tests/MultiTenant/TestMultiTenantKeyProvider.php
+++ b/tests/MultiTenant/TestMultiTenantKeyProvider.php
@@ -1,10 +1,12 @@
 <?php
 namespace ParagonIE\CipherSweet\Tests\MultiTenant;
 
+use ParagonIE\CipherSweet\Backend\Key\SymmetricKey;
 use ParagonIE\CipherSweet\Contract\KeyProviderInterface;
 use ParagonIE\CipherSweet\Contract\MultiTenantAwareProviderInterface;
 use ParagonIE\CipherSweet\Exception\CipherSweetException;
 use ParagonIE\CipherSweet\KeyProvider\MultiTenantProvider;
+use ParagonIE\ConstantTime\Base64UrlSafe;
 
 /**
  * Class TestMultiTenantKeyProvider
@@ -25,7 +27,7 @@ class TestMultiTenantKeyProvider extends MultiTenantProvider
      *
      * @throws CipherSweetException
      */
-    public function getTenantFromRow(array $row)
+    public function getTenantFromRow(array $row, $tableName)
     {
         switch ($row['tenant']) {
             case 'foo':
@@ -33,18 +35,48 @@ class TestMultiTenantKeyProvider extends MultiTenantProvider
             case 'baz':
                 return $row['tenant'];
             default:
-                return parent::getTenantFromRow($row);
+                return parent::getTenantFromRow($row, $tableName);
         }
     }
 
     /**
      * @param array $row
+     * @param string $tableName
      * @return array
      * @throws CipherSweetException
      */
-    public function injectTenantMetadata(array $row)
+    public function injectTenantMetadata(array $row, $tableName)
     {
+        if ($tableName !== 'meta') {
+            $row['tenant-extra'] = $tableName;
+        } else {
+            $row['wrapped-key'] = $this->wrapKey($tableName);
+        }
         $row['tenant'] = $this->active;
         return $row;
+    }
+
+    /**
+     * This is just a dummy key-wrapping example.
+     * You'd really want to use KMS from AWS or GCP.
+     *
+     * @param string $tableName
+     * @return string
+     * @throws CipherSweetException
+     * @throws \SodiumException
+     */
+    protected function wrapKey($tableName = '')
+    {
+        $wrappingKey = sodium_crypto_generichash('unit tests');
+        $nonce = random_bytes(24);
+
+        $wrapped = sodium_crypto_aead_xchacha20poly1305_ietf_encrypt(
+            $this->getActiveTenant()->getSymmetricKey()->getRawKey(),
+            $tableName,
+            $nonce,
+            $wrappingKey
+        );
+
+        return Base64UrlSafe::encode($nonce . $wrapped);
     }
 }

--- a/tests/Rotator/FieldRotatorTest.php
+++ b/tests/Rotator/FieldRotatorTest.php
@@ -42,10 +42,11 @@ class FieldRotatorTest extends TestCase
     protected $naclRandom;
 
     /**
+     * @before
      * @throws ArrayKeyException
      * @throws CryptoOperationException
      */
-    public function setUp()
+    public function before()
     {
         $this->fipsRandom = $this->createFipsEngine();
         $this->naclRandom = $this->createModernEngine();

--- a/tests/Rotator/MultiRowsRotatorTest.php
+++ b/tests/Rotator/MultiRowsRotatorTest.php
@@ -42,10 +42,11 @@ class MultiRowsRotatorTest extends TestCase
     protected $naclRandom;
 
     /**
+     * @before
      * @throws ArrayKeyException
      * @throws CryptoOperationException
      */
-    public function setUp()
+    public function before()
     {
         $this->fipsRandom = $this->createFipsEngine();
         $this->naclRandom = $this->createModernEngine();

--- a/tests/Rotator/RowRotatorTest.php
+++ b/tests/Rotator/RowRotatorTest.php
@@ -42,10 +42,11 @@ class RowRotatorTest extends TestCase
     protected $naclRandom;
 
     /**
+     * @before
      * @throws ArrayKeyException
      * @throws CryptoOperationException
      */
-    public function setUp()
+    public function before()
     {
         $this->fipsRandom = $this->createFipsEngine();
         $this->naclRandom = $this->createModernEngine();


### PR DESCRIPTION
This introduces the concept of multi-tenant-aware providers, which are capable of encrypting with per-user keys without introducing the risk of multi-key attacks against Poly1305. To accomplish this, we specified a new cipher backend called `BoringCrypto` that uses XChaCha20 and BLAKE2b-MAC (Encrypt then MAC) instead of AEAD_XChaCha20_Poly1305. See #59 for the feature request that led to this development.

**Important:** Only `BoringCrypto` and `FipsCrypto` are safe to use with the multi-tenant features of CipherSweet. `ModernCrypto` (the precursor to `BoringCrypto`) is not fit for this purpose.

This PR will be followed by a congruent change to the JavaScript library and then a documentation update before the v3 release is tagged.