### PR TITLE
New Feature: EncryptedJsonField

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -6,6 +6,7 @@
         <directory name="src" />
         <ignoreFiles>
             <directory name="vendor" />
+            <directory name="tests" />
         </ignoreFiles>
     </projectFiles>
 

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -14,6 +14,20 @@ abstract class Constants
     const DS_BIDX = "\x7E\x7E\x7E\x7E\x7E\x7E\x7E\x7E\x7E\x7E\x7E\x7E\x7E\x7E\x7E\x7E\x7E\x7E\x7E\x7E\x7E\x7E\x7E\x7E\x7E\x7E\x7E\x7E\x7E\x7E\x7E\x7E";
     const DS_FENC = "\xB4\xB4\xB4\xB4\xB4\xB4\xB4\xB4\xB4\xB4\xB4\xB4\xB4\xB4\xB4\xB4\xB4\xB4\xB4\xB4\xB4\xB4\xB4\xB4\xB4\xB4\xB4\xB4\xB4\xB4\xB4\xB4";
 
+    /*
+     * Domain separation constant for JSON field key derivation.
+     *
+     * Calculated as: SHA256("json") xor SHA256("JSON")
+     *
+     * 02bd175f329720378ce83dd56a1b6b1f5291a60182d6c54b5e0d1e8d248a267a
+     *                                 xor
+     * db1a21a0bc2ef8fbe13ac4cf044e8c9116d29137d5ed8b916ab63dcb2d4290df
+     *~----------------------------------------------------------------
+     * d9a736ff8eb9d8cc6dd2f91a6e55e78e44433736573b4eda34bb234609c8b6a5
+     */
+    const DS_JSON = "\xD9\xA7\x36\xFF\x8E\xB9\xD8\xCC\x6D\xD2\xF9\x1A\x6E\x55\xE7\x8E\x44\x43\x37\x36\x57\x3B\x4E\xDA\x34\xBB\x23\x46\x09\xC8\xB6\xA5";
+
+    const TYPE_JSON = 'json';
     const TYPE_BOOLEAN = 'bool';
     const TYPE_TEXT = 'string';
     const TYPE_INT = 'int';

--- a/src/EncryptedJsonField.php
+++ b/src/EncryptedJsonField.php
@@ -1,0 +1,246 @@
+<?php
+namespace ParagonIE\CipherSweet;
+
+use ParagonIE\CipherSweet\Backend\Key\SymmetricKey;
+use ParagonIE\CipherSweet\Contract\BackendInterface;
+use ParagonIE\CipherSweet\Exception\CipherSweetException;
+use ParagonIE\CipherSweet\Exception\CryptoOperationException;
+use ParagonIE\CipherSweet\Exception\InvalidCiphertextException;
+use ParagonIE\CipherSweet\Exception\JsonMapException;
+use SodiumException;
+
+class EncryptedJsonField
+{
+    use TypeEncodingTrait;
+
+    /** @var BackendInterface $backend */
+    private $backend;
+
+    /** @var SymmetricKey $rootKey */
+    private $rootKey;
+
+    /** @var JsonFieldMap $fieldMap */
+    private $fieldMap;
+
+    public function __construct(
+        BackendInterface $backend,
+        SymmetricKey $rootKey,
+        JsonFieldMap $fieldMap
+    ) {
+        $this->backend = $backend;
+        $this->rootKey = $rootKey;
+        $this->fieldMap = $fieldMap;
+    }
+
+    /**
+     * @param array<array-key, string|int> $indices
+     * @return self
+     *
+     * @throws JsonMapException
+     */
+    public function addBooleanField($indices)
+    {
+        if (is_string($indices) || is_int($indices)) {
+            $indices = [$indices];
+        }
+        return $this->addField($indices, Constants::TYPE_BOOLEAN);
+    }
+
+    /**
+     * @param array<array-key, string|int> $indices
+     * @return self
+     *
+     * @throws JsonMapException
+     */
+    public function addFloatField($indices)
+    {
+        if (is_string($indices) || is_int($indices)) {
+            $indices = [$indices];
+        }
+        return $this->addField($indices, Constants::TYPE_FLOAT);
+    }
+
+    /**
+     * @param array<array-key, string|int> $indices
+     * @return self
+     *
+     * @throws JsonMapException
+     */
+    public function addIntegerField($indices)
+    {
+        if (is_string($indices) || is_int($indices)) {
+            $indices = [$indices];
+        }
+        return $this->addField($indices, Constants::TYPE_INT);
+    }
+
+    /**
+     * @param array<array-key, string|int> $indices
+     * @return self
+     *
+     * @throws JsonMapException
+     */
+    public function addTextField($indices)
+    {
+        if (is_string($indices) || is_int($indices)) {
+            $indices = [$indices];
+        }
+        return $this->addField($indices, Constants::TYPE_TEXT);
+    }
+
+    /**
+     * @param array<array-key, string|int> $indices
+     * @param string $type
+     * @return self
+     *
+     * @throws JsonMapException
+     */
+    public function addField(array $indices, $type)
+    {
+        $this->fieldMap->addField($indices, $type);
+        return $this;
+    }
+
+    /**
+     * @param string $encoded
+     * @return array
+     *
+     * @throws CipherSweetException
+     */
+    public function decryptJson($encoded)
+    {
+        $field = json_decode($encoded, true);
+        if (!is_array($field)) {
+            throw new CipherSweetException("Could not decode JSON");
+        }
+
+        try {
+            /**
+             * @var array{flat: string, path: array, type: string} $mapped
+             */
+            foreach ($this->fieldMap->getMapping() as $mapped) {
+                /** @var array<array-key, int|string> $path */
+                $path = $mapped['path'];
+                if (empty($path)) {
+                    continue;
+                }
+                /** @var string $type */
+                $type = $mapped['type'];
+                $derivedKey = $this->deriveKey($mapped['flat']);
+                $this->decryptInPlace($derivedKey, $field, $path, $type);
+            }
+            return $field;
+        } catch (SodiumException $ex) {
+            throw new InvalidCiphertextException("Decryption failed", 0, $ex);
+        }
+    }
+
+    /**
+     * @param array $field
+     * @return string
+     *
+     * @throws CryptoOperationException
+     * @throws SodiumException
+     */
+    public function encryptJson(array $field)
+    {
+        /**
+         * @var array{flat: string, path: array, type: string} $mapped
+         */
+        foreach ($this->fieldMap->getMapping() as $mapped) {
+            /** @var array<array-key, int|string> $path */
+            $path = $mapped['path'];
+            if (empty($path)) {
+                continue;
+            }
+            /** @var string $type */
+            $type = $mapped['type'];
+            $derivedKey = $this->deriveKey($mapped['flat']);
+            $this->encryptInPlace($derivedKey, $field, $path, $type);
+        }
+        return json_encode($field);
+    }
+
+    /**
+     * @param string $flatPath
+     * @return SymmetricKey
+     * @throws CryptoOperationException
+     */
+    public function deriveKey($flatPath)
+    {
+        return new SymmetricKey(
+            Util::HKDF(
+                $this->rootKey,
+                null,
+                Constants::DS_JSON . $flatPath
+            )
+        );
+    }
+
+    /**
+     * @param SymmetricKey $derivedKey
+     * @param array<array-key, mixed|array> &$field
+     * @param array<array-key, int|string> $path
+     * @param string $type
+     * @return void
+     *
+     * @throws SodiumException
+     * @psalm-suppress InvalidArgument
+     */
+    public function decryptInPlace(
+        SymmetricKey $derivedKey,
+        array &$field,
+        array $path,
+        $type
+    ) {
+        // Walk down the path
+        $curr = &$field;
+        foreach ($path as $next) {
+            if (!array_key_exists($next, $curr)) {
+                return;
+            }
+            /** @var array<array-key, mixed|array>|null $curr */
+            $curr =& $curr[$next];
+        }
+        if (is_null($curr)) {
+            return;
+        }
+        $decrypted = $this->backend->decrypt($curr, $derivedKey);
+        $curr = $this->convertFromString($decrypted, $type);
+    }
+
+    /**
+     * @param SymmetricKey $derivedKey
+     * @param array<array-key, mixed|array> &$field
+     * @param array<array-key, int|string> $path
+     * @param string $type
+     * @return void
+     *
+     * @throws SodiumException
+     * @psalm-suppress InvalidArgument
+     */
+    public function encryptInPlace(
+        SymmetricKey $derivedKey,
+        array &$field,
+        array $path,
+        $type
+    ) {
+        // Walk down the path
+        $curr = &$field;
+        foreach ($path as $next) {
+            if (!array_key_exists($next, $curr)) {
+                return;
+            }
+
+            /** @var array<array-key, mixed|array>|null $curr */
+            $curr =& $curr[$next];
+        }
+        if (is_null($curr)) {
+            return;
+        }
+        $curr = $this->backend->encrypt(
+            $this->convertToString($curr, $type),
+            $derivedKey
+        );
+    }
+}

--- a/src/EncryptedJsonField.php
+++ b/src/EncryptedJsonField.php
@@ -35,7 +35,7 @@ class EncryptedJsonField
         BackendInterface $backend,
         SymmetricKey $rootKey,
         JsonFieldMap $fieldMap,
-        $strict = false
+        $strict = true
     ) {
         $this->backend = $backend;
         $this->rootKey = $rootKey;
@@ -59,7 +59,7 @@ class EncryptedJsonField
         JsonFieldMap $fieldMap,
         $tableName,
         $fieldName,
-        $strict = false
+        $strict = true
     ) {
         return new self(
             $engine->getBackend(),

--- a/src/EncryptedMultiRows.php
+++ b/src/EncryptedMultiRows.php
@@ -142,6 +142,7 @@ class EncryptedMultiRows
      * @param string $fieldName
      * @param JsonFieldMap $fieldMap
      * @param string $aadSource
+     * @param bool $strict
      * @return self
      *
      * @throws CipherSweetException
@@ -150,10 +151,11 @@ class EncryptedMultiRows
         $tableName,
         $fieldName,
         JsonFieldMap $fieldMap,
-        $aadSource = ''
+        $aadSource = '',
+        $strict = true
     ) {
         $this->getEncryptedRowObjectForTable($tableName)
-            ->addJsonField($fieldName, $fieldMap, $aadSource);
+            ->addJsonField($fieldName, $fieldMap, $aadSource, $strict);
         return $this;
     }
 

--- a/src/EncryptedMultiRows.php
+++ b/src/EncryptedMultiRows.php
@@ -136,6 +136,28 @@ class EncryptedMultiRows
     }
 
     /**
+     * Mark a column to be encryption as a JSON blob.
+     *
+     * @param string $tableName
+     * @param string $fieldName
+     * @param JsonFieldMap $fieldMap
+     * @param string $aadSource
+     * @return self
+     *
+     * @throws CipherSweetException
+     */
+    public function addJsonField(
+        $tableName,
+        $fieldName,
+        JsonFieldMap $fieldMap,
+        $aadSource = ''
+    ) {
+        $this->getEncryptedRowObjectForTable($tableName)
+            ->addJsonField($fieldName, $fieldMap, $aadSource);
+        return $this;
+    }
+
+    /**
      * Mark a column to be encrypted as text input.
      *
      * @param string $tableName

--- a/src/EncryptedRow.php
+++ b/src/EncryptedRow.php
@@ -17,6 +17,8 @@ use SodiumException;
  */
 class EncryptedRow
 {
+    use TypeEncodingTrait;
+
     /**
      * @var CipherSweet $engine
      */
@@ -26,6 +28,9 @@ class EncryptedRow
      * @var array<string, string> $fieldsToEncrypt
      */
     protected $fieldsToEncrypt = [];
+
+    /** @var array<string, JsonFieldMap> $jsonMaps */
+    protected $jsonMaps = [];
 
     /**
      * @var array<string, string> $aadSourceField
@@ -117,6 +122,17 @@ class EncryptedRow
     public function addIntegerField($fieldName, $aadSource = '')
     {
         return $this->addField($fieldName, Constants::TYPE_INT, $aadSource);
+    }
+
+    /**
+     * @param string $fieldName
+     * @param JsonFieldMap $fieldMap
+     * @return self
+     */
+    public function addJsonField($fieldName, JsonFieldMap $fieldMap)
+    {
+        $this->jsonMaps[$fieldName] = $fieldMap;
+        return $this->addField($fieldName, Constants::TYPE_JSON);
     }
 
     /**
@@ -303,17 +319,39 @@ class EncryptedRow
     }
 
     /**
+     * @param string $name
+     * @return JsonFieldMap
+     *
+     * @throws CipherSweetException
+     */
+    public function getJsonFieldMap($name)
+    {
+        if (!\array_key_exists($name, $this->fieldsToEncrypt)) {
+            throw new CipherSweetException("Field does not exist: {$name}");
+        }
+        if ($this->fieldsToEncrypt[$name] !== Constants::TYPE_JSON) {
+            throw new CipherSweetException("Field {$name} is not a JSON field");
+        }
+        if (!\array_key_exists($name, $this->jsonMaps)) {
+            throw new CipherSweetException("JSON Map not found for field {$name}");
+        }
+        return $this->jsonMaps[$name];
+    }
+
+    /**
      * Decrypt all of the appropriate fields in the given array.
      *
      * If any columns are defined in this object to be decrypted, the value
      * will be decrypted in-place in the returned array.
      *
      * @param array<string, string> $row
-     * @return array<string, string|int|float|bool|null>
+     * @return array<string, string|int|float|bool|null|scalar[]>
      * @throws CipherSweetException
      * @throws CryptoOperationException
      * @throws InvalidCiphertextException
      * @throws SodiumException
+     *
+     * @psalm-suppress InvalidReturnStatement
      */
     public function decryptRow(array $row)
     {
@@ -332,6 +370,13 @@ class EncryptedRow
                 $return[$field] = null;
                 continue;
             }
+            if ($type === Constants::TYPE_JSON && !empty($this->jsonMaps[$field])) {
+                // JSON is a special case
+                $jsonEncryptor = new EncryptedJsonField($backend, $key, $this->jsonMaps[$field]);
+                $return[$field] = $jsonEncryptor->decryptJson($row[$field]);
+                continue;
+            }
+
             if (
                 !empty($this->aadSourceField[$field])
                     &&
@@ -376,12 +421,19 @@ class EncryptedRow
                     ' on array, nothing given.'
                 );
             }
-            /** @var string $plaintext */
-            $plaintext = $this->convertToString($row[$field], $type);
             $key = $this->engine->getFieldSymmetricKey(
                 $this->tableName,
                 $field
             );
+            if ($type === Constants::TYPE_JSON && !empty($this->jsonMaps[$field])) {
+                // JSON is a special case
+                $jsonEncryptor = new EncryptedJsonField($backend, $key, $this->jsonMaps[$field]);
+                /** @psalm-suppress InvalidArgument */
+                $return[$field] = $jsonEncryptor->encryptJson($row[$field]);
+                continue;
+            }
+            /** @var string $plaintext */
+            $plaintext = $this->convertToString($row[$field], $type);
             if (
                 !empty($this->aadSourceField[$field])
                     &&
@@ -670,70 +722,6 @@ class EncryptedRow
             $index->getFilterBitLength(),
             $index->getHashConfig()
         );
-    }
-
-    /**
-     * Convert data from decrypted ciphertext into the intended data type
-     * (i.e. the format of the original plaintext before being converted).
-     *
-     * @param string $data
-     * @param string $type
-     * @return int|string|float|bool|null
-     * @throws SodiumException
-     */
-    protected function convertFromString($data, $type)
-    {
-        switch ($type) {
-            case Constants::TYPE_BOOLEAN:
-                return Util::chrToBool($data);
-            case Constants::TYPE_FLOAT:
-                return Util::stringToFloat($data);
-            case Constants::TYPE_INT:
-                return Util::stringToInt($data);
-            default:
-                return (string) $data;
-        }
-    }
-
-    /**
-     * Convert multiple data types to a string prior to encryption.
-     *
-     * The main goals here are:
-     *
-     * 1. Convert several data types to a string.
-     * 2. Leak no information about the original value in the
-     *    output string length.
-     *
-     * @param int|string|float|bool|null $data
-     * @param string $type
-     * @return string
-     * @throws SodiumException
-     */
-    protected function convertToString($data, $type)
-    {
-        switch ($type) {
-            // Will return a 1-byte string:
-            case Constants::TYPE_BOOLEAN:
-                if (!\is_null($data) && !\is_bool($data)) {
-                    $data = !empty($data);
-                }
-                return Util::boolToChr($data);
-            // Will return a fixed-length string:
-            case Constants::TYPE_FLOAT:
-                if (!\is_float($data)) {
-                    throw new \TypeError('Expected a float');
-                }
-                return Util::floatToString($data);
-            // Will return a fixed-length string:
-            case Constants::TYPE_INT:
-                if (!\is_int($data)) {
-                    throw new \TypeError('Expected an integer');
-                }
-                return Util::intToString($data);
-            // Will return the original string, untouched:
-            default:
-                return (string) $data;
-        }
     }
 
     /**

--- a/src/EncryptedRow.php
+++ b/src/EncryptedRow.php
@@ -29,7 +29,9 @@ class EncryptedRow
      */
     protected $fieldsToEncrypt = [];
 
-    /** @var array<string, JsonFieldMap> $jsonMaps */
+    /**
+     * @var array<string, JsonFieldMap> $jsonMaps
+     */
     protected $jsonMaps = [];
 
     /**

--- a/src/EncryptedRow.php
+++ b/src/EncryptedRow.php
@@ -132,9 +132,10 @@ class EncryptedRow
      * @param string $fieldName
      * @param JsonFieldMap $fieldMap
      * @param string $aadSource Field name to source AAD from
+     * @param bool $strict
      * @return self
      */
-    public function addJsonField($fieldName, JsonFieldMap $fieldMap, $aadSource = '')
+    public function addJsonField($fieldName, JsonFieldMap $fieldMap, $aadSource = '', $strict = true)
     {
         $this->jsonMaps[$fieldName] = $fieldMap;
         return $this->addField($fieldName, Constants::TYPE_JSON, $aadSource);

--- a/src/EncryptedRow.php
+++ b/src/EncryptedRow.php
@@ -125,14 +125,17 @@ class EncryptedRow
     }
 
     /**
+     * Define a JSON field that will be encrypted.
+     *
      * @param string $fieldName
      * @param JsonFieldMap $fieldMap
+     * @param string $aadSource Field name to source AAD from
      * @return self
      */
-    public function addJsonField($fieldName, JsonFieldMap $fieldMap)
+    public function addJsonField($fieldName, JsonFieldMap $fieldMap, $aadSource = '')
     {
         $this->jsonMaps[$fieldName] = $fieldMap;
-        return $this->addField($fieldName, Constants::TYPE_JSON);
+        return $this->addField($fieldName, Constants::TYPE_JSON, $aadSource);
     }
 
     /**

--- a/src/Exception/JsonMapException.php
+++ b/src/Exception/JsonMapException.php
@@ -1,0 +1,7 @@
+<?php
+namespace ParagonIE\CipherSweet\Exception;
+
+class JsonMapException extends CipherSweetException
+{
+
+}

--- a/src/JsonFieldMap.php
+++ b/src/JsonFieldMap.php
@@ -1,0 +1,146 @@
+<?php
+namespace ParagonIE\CipherSweet;
+
+use ParagonIE\CipherSweet\Exception\CipherSweetException;
+use ParagonIE\CipherSweet\Exception\JsonMapException;
+use ParagonIE\ConstantTime\Binary;
+use ParagonIE\ConstantTime\Hex;
+
+class JsonFieldMap
+{
+    /** @var array<string, string> */
+    private $fields = [];
+
+    /**
+     * @param array<array-key, string|int> $indices
+     * @return self
+     *
+     * @throws JsonMapException
+     */
+    public function addBooleanField($indices)
+    {
+        if (is_string($indices) || is_int($indices)) {
+            $indices = [$indices];
+        }
+        return $this->addField($indices, Constants::TYPE_BOOLEAN);
+    }
+
+    /**
+     * @param array<array-key, string|int> $indices
+     * @return self
+     *
+     * @throws JsonMapException
+     */
+    public function addFloatField($indices)
+    {
+        if (is_string($indices) || is_int($indices)) {
+            $indices = [$indices];
+        }
+        return $this->addField($indices, Constants::TYPE_FLOAT);
+    }
+
+    /**
+     * @param array<array-key, string|int> $indices
+     * @return self
+     *
+     * @throws JsonMapException
+     */
+    public function addIntegerField($indices)
+    {
+        if (is_string($indices) || is_int($indices)) {
+            $indices = [$indices];
+        }
+        return $this->addField($indices, Constants::TYPE_INT);
+    }
+
+    /**
+     * @param array<array-key, string|int> $indices
+     * @return self
+     *
+     * @throws JsonMapException
+     */
+    public function addTextField($indices)
+    {
+        if (is_string($indices) || is_int($indices)) {
+            $indices = [$indices];
+        }
+        return $this->addField($indices, Constants::TYPE_TEXT);
+    }
+
+    /**
+     * @param array<array-key, string|int> $indices
+     * @param string $type
+     * @return self
+     *
+     * @throws JsonMapException
+     */
+    public function addField(array $indices, $type)
+    {
+        $path = $this->flattenPath($indices);
+        $this->fields[$path] = $type;
+        return $this;
+    }
+
+    /**
+     * @param array<array-key, string|int> $indices
+     * @return string
+     *
+     * @throws JsonMapException
+     */
+    protected function flattenPath(array $indices)
+    {
+        $pieces = [];
+        foreach ($indices as $index) {
+            if (is_int($index)) {
+                $pieces []= '#' . Hex::encode(pack('J', $index));
+            } elseif (is_string($index)) {
+                $pieces []= '$' . Hex::encode($index);
+            } else {
+                throw new JsonMapException('Invalid type');
+            }
+        }
+        return implode('.', $pieces);
+    }
+
+    /**
+     * @param string $flattened
+     * @return array<array-key, string|int>
+     *
+     * @throws CipherSweetException
+     */
+    protected function unflattenPath($flattened)
+    {
+        $pieces = explode('.', $flattened);
+        $path = [];
+        foreach ($pieces as $piece) {
+            $decoded = Hex::decode(Binary::safeSubstr($piece, 1));
+            if ($piece[0] === '#') {
+                $unpack = unpack('J', $decoded);
+                $path[] = $unpack[1];
+            } elseif ($piece[0] === '$') {
+                $path[] = $decoded;
+            } else {
+                throw new CipherSweetException("Unknown path type: {$piece[0]}");
+            }
+        }
+        return $path;
+    }
+
+    /**
+     * @return array
+     *
+     * @throws CipherSweetException
+     */
+    public function getMapping()
+    {
+        $mapping = [];
+        foreach ($this->fields as $field => $type) {
+            $mapping []= [
+                'flat' => $field,
+                'path' => $this->unflattenPath($field),
+                'type' => $type
+            ];
+        }
+        return $mapping;
+    }
+}

--- a/src/TypeEncodingTrait.php
+++ b/src/TypeEncodingTrait.php
@@ -1,0 +1,71 @@
+<?php
+namespace ParagonIE\CipherSweet;
+use SodiumException;
+
+trait TypeEncodingTrait
+{
+    /**
+     * Convert data from decrypted ciphertext into the intended data type
+     * (i.e. the format of the original plaintext before being converted).
+     *
+     * @param string $data
+     * @param string $type
+     * @return int|string|float|bool|null
+     * @throws SodiumException
+     */
+    protected function convertFromString($data, $type)
+    {
+        switch ($type) {
+            case Constants::TYPE_BOOLEAN:
+                return Util::chrToBool($data);
+            case Constants::TYPE_FLOAT:
+                return Util::stringToFloat($data);
+            case Constants::TYPE_INT:
+                return Util::stringToInt($data);
+            default:
+                return (string) $data;
+        }
+    }
+
+    /**
+     * Convert multiple data types to a string prior to encryption.
+     *
+     * The main goals here are:
+     *
+     * 1. Convert several data types to a string.
+     * 2. Leak no information about the original value in the
+     *    output string length.
+     *
+     * @param int|string|float|bool|null $data
+     * @param string $type
+     * @return string
+     * @throws SodiumException
+     */
+    protected function convertToString($data, $type)
+    {
+        switch ($type) {
+            // Will return a 1-byte string:
+            case Constants::TYPE_BOOLEAN:
+                if (!\is_null($data) && !\is_bool($data)) {
+                    $data = !empty($data);
+                }
+                return Util::boolToChr($data);
+            // Will return a fixed-length string:
+            case Constants::TYPE_FLOAT:
+                if (!\is_float($data)) {
+                    throw new \TypeError('Expected a float');
+                }
+                return Util::floatToString($data);
+            // Will return a fixed-length string:
+            case Constants::TYPE_INT:
+                if (!\is_int($data)) {
+                    throw new \TypeError('Expected an integer');
+                }
+                return Util::intToString($data);
+            // Will return the original string, untouched:
+            default:
+                return (string) $data;
+        }
+    }
+
+}

--- a/tests/EncryptedJsonFieldTest.php
+++ b/tests/EncryptedJsonFieldTest.php
@@ -1,0 +1,190 @@
+<?php
+namespace ParagonIE\CipherSweet\Tests;
+
+use ParagonIE\CipherSweet\CipherSweet;
+use ParagonIE\CipherSweet\EncryptedJsonField;
+use ParagonIE\CipherSweet\Exception\ArrayKeyException;
+use ParagonIE\CipherSweet\Exception\CryptoOperationException;
+use ParagonIE\CipherSweet\Exception\InvalidCiphertextException;
+use ParagonIE\CipherSweet\Exception\JsonMapException;
+use ParagonIE\CipherSweet\JsonFieldMap;
+use ParagonIE\ConstantTime\Hex;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @psalm-suppress
+ */
+class EncryptedJsonFieldTest extends TestCase
+{
+    use CreatesEngines;
+
+    /**
+     * @var CipherSweet $fipsEngine
+     */
+    protected $fipsEngine;
+
+    /**
+     * @var CipherSweet $boringEngine
+     */
+    protected $boringEngine;
+
+    /**
+     * @var CipherSweet $fipsRandom
+     */
+    protected $fipsRandom;
+
+    /**
+     * @var CipherSweet $boringRandom
+     */
+    protected $boringRandom;
+
+    /**
+     * @before
+     *
+     * @throws ArrayKeyException
+     * @throws CryptoOperationException
+     */
+    public function before()
+    {
+        $this->fipsEngine = $this->createFipsEngine('4e1c44f87b4cdf21808762970b356891db180a9dd9850e7baf2a79ff3ab8a2fc');
+        $this->boringEngine = $this->createBoringEngine('4e1c44f87b4cdf21808762970b356891db180a9dd9850e7baf2a79ff3ab8a2fc');
+
+        $this->fipsRandom = $this->createFipsEngine();
+        $this->boringRandom = $this->createBoringEngine();
+    }
+
+    public function engineProvider()
+    {
+        if (!isset($this->fipsEngine)) {
+            $this->before();
+        }
+        return [
+            [$this->fipsEngine],
+            [$this->fipsRandom],
+            [$this->boringEngine],
+            [$this->boringRandom]
+        ];
+    }
+
+    /**
+     * @dataProvider engineProvider
+     */
+    public function testDeriveKey(CipherSweet $engine)
+    {
+        $ejf = new EncryptedJsonField(
+            $engine->getBackend(),
+            $engine->getFieldSymmetricKey('table_name', 'field_name'),
+            new JsonFieldMap()
+        );
+
+        $key1 = Hex::encode($ejf->deriveKey('$666f6f.$626172')->getRawKey());
+        $key2 = Hex::encode($ejf->deriveKey('$626172.$62617a')->getRawKey());
+        $this->assertNotSame($key1, $key2);
+
+        $ejf2 = new EncryptedJsonField(
+            $engine->getBackend(),
+            $engine->getFieldSymmetricKey('table_name', 'different_field'),
+            new JsonFieldMap()
+        );
+
+        $key3 = Hex::encode($ejf2->deriveKey('$666f6f.$626172')->getRawKey());
+        $key4 = Hex::encode($ejf2->deriveKey('$626172.$62617a')->getRawKey());
+        $this->assertNotSame($key3, $key4);
+
+        $this->assertNotSame($key1, $key3);
+        $this->assertNotSame($key2, $key4);
+    }
+
+    /**
+     * @dataProvider engineProvider
+     *
+     * @throws JsonMapException
+     */
+    public function testFieldEncryption(CipherSweet $engine)
+    {
+        $map = (new JsonFieldMap())
+            ->addTextField(['name'])
+            ->addBooleanField(['active'])
+            ->addIntegerField(['age'])
+            ->addFloatField(['latitude'])
+            ->addFloatField(['longitude']);
+
+        $ejf = new EncryptedJsonField(
+            $engine->getBackend(),
+            $engine->getKeyProvider()->getSymmetricKey(),
+            $map
+        );
+
+        $plaintext = [
+            'id' => 12345,
+            'name' => 'foo',
+            'active' => (random_int(0, 1) === 1),
+            'age' => random_int(18,100),
+            'latitude' => 37.2431,
+            'longitude' => 115.7930
+        ];
+        $encrypted = $ejf->encryptJson($plaintext);
+
+        $encArray = json_decode($encrypted, true);
+        $prefix = $engine->getBackend()->getPrefix();
+
+        $this->assertStringStartsNotWith($prefix, $encArray['id'], 'id should not be encrypted');
+        $this->assertStringStartsWith($prefix, $encArray['name'], 'field "name" should be encrypted');
+        $this->assertStringStartsWith($prefix, $encArray['active'], 'field "active" should be encrypted');
+        $this->assertStringStartsWith($prefix, $encArray['age'], 'field "age" should be encrypted');
+        $this->assertStringStartsWith($prefix, $encArray['latitude'], 'field "latitude" should be encrypted');
+        $this->assertStringStartsWith($prefix, $encArray['longitude'], 'field "longitude" should be encrypted');
+
+        $decrypted = $ejf->decryptJson($encrypted);
+
+        $this->assertEquals($plaintext['name'], $decrypted['name']);
+        $this->assertEquals($plaintext['active'], $decrypted['active']);
+        $this->assertEquals($plaintext['age'], $decrypted['age']);
+        $this->assertEqualsWithDelta($plaintext['latitude'], $decrypted['latitude'], 0.00000001);
+        $this->assertEqualsWithDelta($plaintext['longitude'], $decrypted['longitude'], 0.00000001);
+    }
+
+    /**
+     * @dataProvider engineProvider
+     *
+     * @throws JsonMapException
+     */
+    public function testUnhappyPath(CipherSweet $engine)
+    {
+        $map = (new JsonFieldMap())
+            ->addTextField(['name'])
+            ->addBooleanField(['active'])
+            ->addIntegerField(['age'])
+            ->addFloatField(['latitude'])
+            ->addFloatField(['longitude']);
+
+        $ejf = new EncryptedJsonField(
+            $engine->getBackend(),
+            $engine->getKeyProvider()->getSymmetricKey(),
+            $map
+        );
+
+        $plaintext = [
+            'id' => 12345,
+            'name' => 'foo',
+            'active' => (random_int(0, 1) === 1),
+            'age' => random_int(18,100),
+            'latitude' => 37.2431,
+            'longitude' => 115.7930
+        ];
+        $encrypted = $ejf->encryptJson($plaintext);
+
+        $encArray = json_decode($encrypted, true);
+        $copy = $encArray;
+
+        // Let's swap two fields
+        $copy['active'] = $encArray['age'];
+        $copy['age'] = $encArray['active'];
+
+        // Attempt decryption
+        $this->expectException(InvalidCiphertextException::class);
+        $ejf->decryptJson(json_encode($copy));
+
+        $this->fail("Expected exception was not thrown");
+    }
+}

--- a/tests/JsonFieldMapTest.php
+++ b/tests/JsonFieldMapTest.php
@@ -4,6 +4,7 @@ namespace ParagonIE\CipherSweet\Tests;
 use ParagonIE\CipherSweet\Constants;
 use ParagonIE\CipherSweet\JsonFieldMap;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Util\Json;
 
 /**
  * @psalm-suppress
@@ -16,7 +17,10 @@ class JsonFieldMapTest extends TestCase
             ->addField(['foo', 'bar'], Constants::TYPE_TEXT)
             ->addField(['bar', 'baz'], Constants::TYPE_INT);
 
+        $original = $mapper->toString();
         $mapped = $mapper->getMapping();
+        $copy = $mapped;
+
         $this->assertCount(2, $mapped);
 
         $this->assertSame(['foo', 'bar'], $mapped[0]['path']);
@@ -39,5 +43,17 @@ class JsonFieldMapTest extends TestCase
         );
         $this->assertSame(['foo', 0, 'bar', 123], $mapped[2]['path']);
         $this->assertSame(Constants::TYPE_BOOLEAN, $mapped[2]['type']);
+
+        $updated = $mapper->toString();
+        $restored = JsonFieldMap::fromString($original);
+
+        $old = $restored->getMapping();
+        $this->assertCount(2, $old);
+        $this->assertSame($old, $copy);
+
+        $threeFields = JsonFieldMap::fromString($updated);
+        $new = $threeFields->getMapping();
+        $this->assertCount(3, $new);
+        $this->assertSame($mapped, $new);
     }
 }

--- a/tests/JsonFieldMapTest.php
+++ b/tests/JsonFieldMapTest.php
@@ -1,0 +1,43 @@
+<?php
+namespace ParagonIE\CipherSweet\Tests;
+
+use ParagonIE\CipherSweet\Constants;
+use ParagonIE\CipherSweet\JsonFieldMap;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @psalm-suppress
+ */
+class JsonFieldMapTest extends TestCase
+{
+    public function testFlatten()
+    {
+        $mapper = (new JsonFieldMap())
+            ->addField(['foo', 'bar'], Constants::TYPE_TEXT)
+            ->addField(['bar', 'baz'], Constants::TYPE_INT);
+
+        $mapped = $mapper->getMapping();
+        $this->assertCount(2, $mapped);
+
+        $this->assertSame(['foo', 'bar'], $mapped[0]['path']);
+        $this->assertSame(['bar', 'baz'], $mapped[1]['path']);
+
+        $this->assertSame('$666f6f.$626172', $mapped[0]['flat']);
+        $this->assertSame('$626172.$62617a', $mapped[1]['flat']);
+
+        $this->assertSame(Constants::TYPE_TEXT, $mapped[0]['type']);
+        $this->assertSame(Constants::TYPE_INT, $mapped[1]['type']);
+
+        // Let's add a field:
+        $mapper->addBooleanField(['foo', 0, 'bar', 123]);
+        $mapped = $mapper->getMapping();
+
+        $this->assertCount(3, $mapped);
+        $this->assertSame(
+            '$666f6f.#0000000000000000.$626172.#000000000000007b',
+            $mapped[2]['flat']
+        );
+        $this->assertSame(['foo', 0, 'bar', 123], $mapped[2]['path']);
+        $this->assertSame(Constants::TYPE_BOOLEAN, $mapped[2]['type']);
+    }
+}

--- a/tests/JsonFieldMapTest.php
+++ b/tests/JsonFieldMapTest.php
@@ -4,7 +4,6 @@ namespace ParagonIE\CipherSweet\Tests;
 use ParagonIE\CipherSweet\Constants;
 use ParagonIE\CipherSweet\JsonFieldMap;
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Util\Json;
 
 /**
  * @psalm-suppress


### PR DESCRIPTION
This is useful for encrypting parts of a JSON field (e.g. JSONB in PostgreSQL).

Every JSON field uses a root key (which is the same as the per-field symmetric key), from which it derives a distinct key for each encrypted JSON attribute. The full canonical path of the element in the JSON document is used for key derivation.

Any attempt to restructure the document or replay ciphertexts in the wrong attribute will cause a decryption failure.