### PR TITLE
Support json field map templating

### DIFF
--- a/src/JsonFieldMap.php
+++ b/src/JsonFieldMap.php
@@ -128,6 +128,30 @@ class JsonFieldMap
     }
 
     /**
+     * Adds an object's configuration
+     *
+     * @param array|int|string $rootIndices
+     * @param JsonFieldMap $template
+     * @return static
+     *
+     * @throws CipherSweetException
+     */
+    public function addMapFieldFromTemplate(
+        array|int|string $rootIndices,
+        JsonFieldMap $template
+    ): static {
+        if (\is_string($rootIndices) || \is_int($rootIndices)) {
+            $rootIndices = [$rootIndices];
+        }
+
+        foreach ($template->getMapping() as $mapping) {
+            $indices = [...$rootIndices, ...$mapping['path']];
+            $this->addField($indices, $mapping['type']);
+        }
+        return $this;
+    }
+
+    /**
      * @param array<array-key, string|int> $indices
      * @return string
      *

--- a/tests/JsonFieldMapTest.php
+++ b/tests/JsonFieldMapTest.php
@@ -55,4 +55,25 @@ class JsonFieldMapTest extends TestCase
         $this->assertCount(3, $new);
         $this->assertSame($mapped, $new);
     }
+
+    public function testTemplate()
+    {
+        $parent = new JsonFieldMap();
+        $template = (new JsonFieldMap())
+            ->addTextField(['foo', 'bar'])
+            ->addIntegerField(['bar', 'baz']);
+        $parent->addMapFieldFromTemplate(['data', 0], $template);
+        $parent->addMapFieldFromTemplate(['data', 1], $template);
+
+        $mapping = $parent->toString();
+        $this->assertSame(
+            '3be7ae2c{"fields":{' .
+                '"$64617461.#0000000000000000.$666f6f.$626172":"string",' .
+                '"$64617461.#0000000000000000.$626172.$62617a":"int",' .
+                '"$64617461.#0000000000000001.$666f6f.$626172":"string",' .
+                '"$64617461.#0000000000000001.$626172.$62617a":"int"' .
+            '}}',
+            $mapping
+        );
+    }
 }


### PR DESCRIPTION
To create a field definition dynamically, you can add subfields to an arbitrary depth at any time.

See the new unit test for more details.