### PR TITLE
Explicit support for optional field types

### DIFF
--- a/src/Constants.php
+++ b/src/Constants.php
@@ -48,6 +48,17 @@ abstract class Constants
     const TYPE_INT = 'int';
     const TYPE_FLOAT = 'float';
 
+    const TYPE_OPTIONAL_JSON = '?json';
+    const TYPE_OPTIONAL_BOOLEAN = '?bool';
+    const TYPE_OPTIONAL_TEXT = '?string';
+    const TYPE_OPTIONAL_INT = '?int';
+    const TYPE_OPTIONAL_FLOAT = '?float';
+
+    // Lists of type constants for ease-of-inlining
+    const TYPES_OPTIONAL = ['?json', '?bool', '?string', '?int', '?float'];
+    const TYPES_BOOLEAN = ['?bool', 'bool'];
+    const TYPES_JSON = ['?json', 'json'];
+
     const COMPOUND_SPECIAL = 'special__compound__indexes';
 
     const FILE_TABLE = "special__file__encryption";

--- a/src/EncryptedMultiRows.php
+++ b/src/EncryptedMultiRows.php
@@ -168,6 +168,96 @@ class EncryptedMultiRows
         );
     }
 
+
+    /**
+     * Mark a column to be encrypted as boolean input. Permits NULL.
+     *
+     * @throws CipherSweetException
+     */
+    public function addOptionalBooleanField(
+        string $tableName,
+        string $fieldName,
+        string $aadSource = ''
+    ): static {
+        return $this->addField(
+            $tableName,
+            $fieldName,
+            Constants::TYPE_OPTIONAL_BOOLEAN,
+            $aadSource
+        );
+    }
+
+    /**
+     * Mark a column to be encrypted as floating point input. Permits NULL.
+     *
+     * @throws CipherSweetException
+     */
+    public function addOptionalFloatField(
+        string $tableName,
+        string $fieldName,
+        string $aadSource = ''
+    ): static {
+        return $this->addField(
+            $tableName,
+            $fieldName,
+            Constants::TYPE_OPTIONAL_FLOAT,
+            $aadSource
+        );
+    }
+
+    /**
+     * Mark a column to be encrypted as integer input. Permits NULL.
+     *
+     * @throws CipherSweetException
+     */
+    public function addOptionalIntegerField(
+        string $tableName,
+        string $fieldName,
+        string $aadSource = ''
+    ): static {
+        return $this->addField(
+            $tableName,
+            $fieldName,
+            Constants::TYPE_OPTIONAL_INT,
+            $aadSource
+        );
+    }
+
+    /**
+     * Mark a column to be encryption as a JSON blob. Permits NULL.
+     *
+     * @throws CipherSweetException
+     */
+    public function addOptionalJsonField(
+        string $tableName,
+        string $fieldName,
+        JsonFieldMap $fieldMap,
+        string $aadSource = '',
+        bool $strict = true
+    ): static {
+        $this->getEncryptedRowObjectForTable($tableName)
+            ->addNullableJsonField($fieldName, $fieldMap, $aadSource, $strict);
+        return $this;
+    }
+
+    /**
+     * Mark a column to be encrypted as text input. Permits NULL.
+     *
+     * @throws CipherSweetException
+     */
+    public function addOptionalTextField(
+        string $tableName,
+        string $fieldName,
+        string $aadSource = ''
+    ): static {
+        return $this->addField(
+            $tableName,
+            $fieldName,
+            Constants::TYPE_OPTIONAL_TEXT,
+            $aadSource
+        );
+    }
+
     /**
      * Add a blind index to a specific table.
      * @throws CipherSweetException

--- a/src/EncryptedRow.php
+++ b/src/EncryptedRow.php
@@ -15,6 +15,11 @@ use ParagonIE\CipherSweet\Exception\{
 use ParagonIE\ConstantTime\Hex;
 use SodiumException;
 use TypeError;
+use function
+    array_key_exists,
+    in_array,
+    is_null,
+    is_scalar;
 
 /**
  * Class EncryptedRow
@@ -573,7 +578,7 @@ class EncryptedRow
         $return = $row;
         $backend = $this->engine->getBackend();
         foreach ($this->fieldsToEncrypt as $field => $type) {
-            if (!\array_key_exists($field, $row)) {
+            if (!array_key_exists($field, $row)) {
                 throw new ArrayKeyException(
                     'Expected value for column ' .
                         $field .
@@ -587,7 +592,7 @@ class EncryptedRow
             if (
                 !empty($this->aadSourceField[$field])
                     &&
-                \array_key_exists($this->aadSourceField[$field], $row)
+                array_key_exists($this->aadSourceField[$field], $row)
             ) {
                 $aad = $this->coaxAadToString($row[$this->aadSourceField[$field]]);
             } else {

--- a/src/EncryptedRow.php
+++ b/src/EncryptedRow.php
@@ -149,6 +149,74 @@ class EncryptedRow
     }
 
     /**
+     * Define a boolean field that will be encrypted. Permits NULL.
+     *
+     * @param string $fieldName
+     * @param string $aadSource Field name to source AAD from
+     * @return static
+     */
+    public function addOptionalBooleanField(string $fieldName, string $aadSource = ''): static
+    {
+        return $this->addField($fieldName, Constants::TYPE_OPTIONAL_BOOLEAN, $aadSource);
+    }
+
+    /**
+     * Define a floating point number (decimal) field that will be encrypted. Permits NULL.
+     *
+     * @param string $fieldName
+     * @param string $aadSource Field name to source AAD from
+     * @return static
+     */
+    public function addOptionalFloatField(string $fieldName, string $aadSource = ''): static
+    {
+        return $this->addField($fieldName, Constants::TYPE_OPTIONAL_FLOAT, $aadSource);
+    }
+
+    /**
+     * Define an integer field that will be encrypted. Permits NULL.
+     *
+     * @param string $fieldName
+     * @param string $aadSource Field name to source AAD from
+     * @return static
+     */
+    public function addOptionalIntegerField(string $fieldName, string $aadSource = ''): static
+    {
+        return $this->addField($fieldName, Constants::TYPE_OPTIONAL_INT, $aadSource);
+    }
+
+    /**
+     * Define an integer field that will be encrypted. Permits NULL.
+     *
+     * @param string $fieldName
+     * @param string $aadSource Field name to source AAD from
+     * @return static
+     */
+    public function addOptionalTextField(string $fieldName, string $aadSource = ''): static
+    {
+        return $this->addField($fieldName, Constants::TYPE_OPTIONAL_TEXT, $aadSource);
+    }
+
+    /**
+     * Define a JSON field that will be encrypted. Permits NULL.
+     *
+     * @param string $fieldName
+     * @param JsonFieldMap $fieldMap
+     * @param string $aadSource Field name to source AAD from
+     * @param bool $strict
+     * @return static
+     */
+    public function addNullableJsonField(
+        string $fieldName,
+        JsonFieldMap $fieldMap,
+        string $aadSource = '',
+        bool $strict = true
+    ): static {
+        $this->jsonMaps[$fieldName] = $fieldMap;
+        $this->jsonStrict[$fieldName] = $strict;
+        return $this->addField($fieldName, Constants::TYPE_OPTIONAL_JSON, $aadSource);
+    }
+
+    /**
      * Define a JSON field that will be encrypted.
      *
      * @param string $fieldName
@@ -445,9 +513,16 @@ class EncryptedRow
                 }
                 continue;
             }
-            if (\is_null($row[$field])) {
-                $return[$field] = null;
-                continue;
+            // Support for nullable types
+            if (in_array($type, Constants::TYPES_OPTIONAL, true)) {
+                if (is_null($row[$field])) {
+                    $return[$field] = null;
+                    continue;
+                }
+            }
+            // Encrypted booleans will be scalar values as ciphertext
+            if (!is_scalar($row[$field])) {
+                throw new TypeError('Invalid type for ' . $field);
             }
             if (
                 !empty($this->aadSourceField[$field])
@@ -459,7 +534,7 @@ class EncryptedRow
                 $aad = '';
             }
 
-            if ($type === Constants::TYPE_JSON && !empty($this->jsonMaps[$field])) {
+            if (in_array($type, Constants::TYPES_JSON, true) && !empty($this->jsonMaps[$field])) {
                 // JSON is a special case
                 $jsonEncryptor = new EncryptedJsonField(
                     $backend,
@@ -518,7 +593,7 @@ class EncryptedRow
             } else {
                 $aad = '';
             }
-            if ($type === Constants::TYPE_JSON && !empty($this->jsonMaps[$field])) {
+            if (in_array($type, Constants::TYPES_JSON, true) && !empty($this->jsonMaps[$field])) {
                 // JSON is a special case
                 $jsonEncryptor = new EncryptedJsonField(
                     $backend,
@@ -529,7 +604,24 @@ class EncryptedRow
                 $return[$field] = $jsonEncryptor->encryptJson($this->coaxToArray($row[$field]), $aad);
                 continue;
             }
+
+            // Support nullable types
+            if (in_array($type, Constants::TYPES_OPTIONAL, true)) {
+                if (is_null($row[$field])) {
+                    continue;
+                }
+            }
+
+            // Boolean always supported NULL as a value to encrypt
+            if (in_array($type, Constants::TYPES_BOOLEAN, true) && is_null($row[$field])) {
+                $plaintext = $this->convertToString($row[$field], Constants::TYPE_BOOLEAN);
+                $return[$field] = $backend->encrypt($plaintext, $key, $aad);
+                continue;
+            }
+
+            // All others must be scalar
             if (!is_scalar($row[$field])) {
+                // NULL is not permitted.
                 throw new TypeError('Invalid type for ' . $field);
             }
             $plaintext = $this->convertToString($row[$field], $type);

--- a/src/TypeEncodingTrait.php
+++ b/src/TypeEncodingTrait.php
@@ -15,10 +15,13 @@ trait TypeEncodingTrait
     protected function convertFromString(string $data, string $type): int|string|float|bool|null
     {
         return match ($type) {
-            Constants::TYPE_BOOLEAN => Util::chrToBool($data),
-            Constants::TYPE_FLOAT => Util::stringToFloat($data),
-            Constants::TYPE_INT => Util::stringToInt($data),
-            default => (string) $data,
+            Constants::TYPE_OPTIONAL_BOOLEAN, Constants::TYPE_BOOLEAN =>
+                Util::chrToBool($data),
+            Constants::TYPE_OPTIONAL_FLOAT, Constants::TYPE_FLOAT =>
+                Util::stringToFloat($data),
+            Constants::TYPE_OPTIONAL_INT, Constants::TYPE_INT =>
+                Util::stringToInt($data),
+            default => $data,
         };
     }
 
@@ -37,18 +40,21 @@ trait TypeEncodingTrait
     {
         switch ($type) {
             // Will return a 1-byte string:
+            case Constants::TYPE_OPTIONAL_BOOLEAN:
             case Constants::TYPE_BOOLEAN:
                 if (!\is_null($data) && !\is_bool($data)) {
                     $data = !empty($data);
                 }
                 return Util::boolToChr($data);
             // Will return a fixed-length string:
+            case Constants::TYPE_OPTIONAL_FLOAT:
             case Constants::TYPE_FLOAT:
                 if (!\is_float($data)) {
                     throw new \TypeError('Expected a float');
                 }
                 return Util::floatToString($data);
             // Will return a fixed-length string:
+            case Constants::TYPE_OPTIONAL_INT:
             case Constants::TYPE_INT:
                 if (!\is_int($data)) {
                     throw new \TypeError('Expected an integer');

--- a/tests/EncryptedMultiRowsTest.php
+++ b/tests/EncryptedMultiRowsTest.php
@@ -283,4 +283,28 @@ class EncryptedMultiRowsTest extends TestCase
             [$this->boringRandom]
         ];
     }
+
+    /**
+     * @dataProvider engineProvider
+     */
+    public function testOptionalFields(CipherSweet $engine): void
+    {
+        $eR = new EncryptedMultiRows($engine);
+        $eR
+            ->addOptionalBooleanField('foo', 'bar')
+            ->addOptionalFloatField('foo', 'baz')
+            ->addOptionalIntegerField('foo', 'qux')
+            ->addOptionalTextField('foo', 'quux');
+
+        $null = ['foo' => ['bar' => null, 'baz' => null, 'qux' => null, 'quux' => null]];
+        $encrypted = $eR->encryptManyRows($null);
+        $this->assertSame($null, $encrypted);
+
+        // Boolean fields treat NULl as a value. Optional booleans do not.
+        $eR->addBooleanField('foo', 'testing');
+        $null['foo']['testing'] = null;
+        $encrypted = $eR->encryptManyRows($null);
+        $this->assertNotSame($null, $encrypted);
+
+    }
 }

--- a/tests/EncryptedRowTest.php
+++ b/tests/EncryptedRowTest.php
@@ -518,4 +518,27 @@ class EncryptedRowTest extends TestCase
         $this->assertSame(1234, $array['qux']);
         $this->assertSame($plaintext, $eR->decryptRow($some));
     }
+
+    /**
+     * @dataProvider engineProvider
+     */
+    public function tesOptionalFields(CipherSweet $engine): void
+    {
+        $eR = new EncryptedRow($engine, 'foo');
+        $eR
+            ->addOptionalBooleanField('bar')
+            ->addOptionalFloatField('baz')
+            ->addOptionalIntegerField('qux')
+            ->addOptionalTextField('quux');
+
+        $null = ['bar' => null, 'baz' => null, 'qux' => null, 'quux' => null];
+        $encrypted = $eR->encryptRow($null);
+        $this->assertSame($null, $encrypted);
+
+        // Boolean fields treat NULl as a value. Optional booleans do not.
+        $eR->addBooleanField('testing');
+        $null['testing'] = null;
+        $encrypted = $eR->encryptRow($null);
+        $this->assertNotSame($null, $encrypted);
+    }
 }


### PR DESCRIPTION
You can now define optional fields. These do not encrypt when NULL is provided as a value. Instead, they become an unencrypted NULL.

EncryptedRow:
  - foo, OptionalText
  - bar, OptionalText

Plaintext: ['foo' => 'abc', 'bar' => null]
Ciphertext: ['foo' => /* encrypted */, 'bar' => null]

These are called "optional" types to disambiguate with NULL support. This matters because Boolean fields always supported NULL under-the-hood.

## Types Mapping with Optional

- Boolean:
  - (true) -> (ciphertext)
  - (false) -> (ciphertext)
  - (null) -> (ciphertext)
- Integer:
  - (int) -> (ciphertext)
  - (null) -> TypeError
- Float:
  - (float) -> (ciphertext)
  - (null) -> TypeError
- JSON:
  - (json) -> (ciphertext)
  - (null) -> TypeError
- Text:
  - (string) -> (ciphertext)
  - (null) -> TypeError
- OptionalBoolean:
  - (true) -> (ciphertext)
  - (false) -> (ciphertext)
  - (null) -> (null)
- OptionalInteger:
  - (int) -> (ciphertext)
  - (null) -> (null)
- OptionalFloat:
  - (float) -> (ciphertext)
  - (null) -> (null)
- OptionalJSON:
  - (json) -> (ciphertext)
  - (null) -> (null)
- OptionalText:
  - (string) -> (ciphertext)
  - (null) -> (null)