### PR TITLE
Allow multi-tenant providers to use static blind index keys

### DIFF
--- a/src/Contract/StaticBlindIndexKeyProviderInterface.php
+++ b/src/Contract/StaticBlindIndexKeyProviderInterface.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+namespace ParagonIE\CipherSweet\Contract;
+
+/**
+ * Enables Key Providers to enable/disable using a specific, static "Tenant" for deriving the root keys
+ * for Blind Indexes and Compound Indexes.
+ */
+interface StaticBlindIndexKeyProviderInterface extends MultiTenantAwareProviderInterface
+{
+    public function getStaticBlindIndexTenant(): string|int|null;
+    public function setStaticBlindIndexTenant(string|int|null $tenant = null): void;
+}

--- a/tests/MultiTenant/SBKP.php
+++ b/tests/MultiTenant/SBKP.php
@@ -1,0 +1,23 @@
+<?php
+namespace ParagonIE\CipherSweet\Tests\MultiTenant;
+
+use ParagonIE\CipherSweet\Contract\StaticBlindIndexKeyProviderInterface;
+
+/**
+ * Class TestMultiTenantKeyProvider
+ * @package ParagonIE\CipherSweet\Tests\MultiTenant
+ */
+class SBKP extends TestMultiTenantKeyProvider implements StaticBlindIndexKeyProviderInterface
+{
+    protected string|int|null $blindIndexTenant = null;
+
+    public function getStaticBlindIndexTenant(): string|int|null
+    {
+        return $this->blindIndexTenant;
+    }
+
+    public function setStaticBlindIndexTenant(int|string|null $tenant = null): void
+    {
+        $this->blindIndexTenant = $tenant;
+    }
+}


### PR DESCRIPTION
See https://github.com/paragonie/ciphersweet-provider-aws-kms/issues/1