### PR TITLE
Add PHP 8.1+ Enum support for EncryptedRow

### DIFF
--- a/src/EncryptedRow.php
+++ b/src/EncryptedRow.php
@@ -646,6 +646,10 @@ class EncryptedRow
                 continue;
             }
 
+            // check enum values
+            if ($row[$field] instanceof \UnitEnum) {
+                $row[$field] = self::enumToScalar($row[$field]);
+            }
             // All others must be scalar
             if (!is_scalar($row[$field])) {
                 // NULL is not permitted.
@@ -714,6 +718,27 @@ class EncryptedRow
     {
         $this->aadSourceField[$fieldName] = AAD::field($aadSource);
         return $this;
+    }
+
+    /**
+     * Return a scalar value for the given value that might be an enum.
+     * 
+     * @internal
+     *
+     * @param mixed $value
+     * @param mixed $default
+     * @return mixed
+     */
+    private static function enumToScalar(mixed $value, mixed $default = null): mixed
+    {
+        if (\function_exists('enum_value')) {
+            return enum_value($value, $default);
+        }
+        return match (true) {
+            $value instanceof \BackedEnum => $value->value,
+            $value instanceof \UnitEnum => $value->name,
+            default => $value ?? (\is_callable($default) ? $default($value) : $default),
+        };
     }
 
     /**
@@ -860,6 +885,9 @@ class EncryptedRow
 
         /** @var string|bool|int|float|null $unconverted */
         $unconverted = $row[$column];
+        if ($unconverted instanceof \UnitEnum) {
+            $unconverted = self::enumToScalar($unconverted);
+        }
 
         $plaintext = $index->getTransformed(
             $this->convertToString($unconverted, $fieldType)

--- a/tests/EncryptedRowTest.php
+++ b/tests/EncryptedRowTest.php
@@ -27,6 +27,18 @@ use PHPUnit\Framework\TestCase;
 use ParagonIE\CipherSweet\Tests\Transformation\FirstInitialLastName;
 use SodiumException;
 
+enum TestBackedEnum: string
+{
+    case Active = 'active';
+    case Inactive = 'inactive';
+}
+
+enum TestUnitEnum
+{
+    case Pending;
+    case Approved;
+}
+
 /**
  * Class EncryptedRowTest
  * @package ParagonIE\CipherSweet\Tests
@@ -658,5 +670,60 @@ class EncryptedRowTest extends TestCase
             ' declaration from Constants::TYPE_TEXT to Constants::TYPE_OPTIONAL_TEXT.'
         );
         $eR->encryptRow($null);
+    }
+
+    /**
+     * @throws ArrayKeyException
+     * @throws CryptoOperationException
+     * @throws InvalidCiphertextException
+     * @throws SodiumException
+     */
+    public function testEncryptRowWithEnumValues(): void
+    {
+        $eR = (new EncryptedRow($this->brngRandom, 'contacts'));
+        $eR->addTextField('status');
+        $eR->addTextField('state');
+
+        // Test BackedEnum - should use ->value ('active')
+        $rowWithBackedEnum = [
+            'status' => TestBackedEnum::Active,
+            'state' => 'normal',
+        ];
+        $encrypted = $eR->encryptRow($rowWithBackedEnum);
+        $this->assertArrayHasKey('status', $encrypted);
+        $this->assertIsString($encrypted['status']);
+        $decrypted = $eR->decryptRow($encrypted);
+        $this->assertSame('active', $decrypted['status']);
+        $this->assertSame('normal', $decrypted['state']);
+
+        // Test UnitEnum - should use ->name ('Pending')
+        $rowWithUnitEnum = [
+            'status' => TestUnitEnum::Pending,
+            'state' => 'normal',
+        ];
+        $encrypted = $eR->encryptRow($rowWithUnitEnum);
+        $decrypted = $eR->decryptRow($encrypted);
+        $this->assertSame('Pending', $decrypted['status']);
+        $this->assertSame('normal', $decrypted['state']);
+    }
+
+    /**
+     * @throws ArrayKeyException
+     * @throws CryptoOperationException
+     * @throws SodiumException
+     */
+    public function testGetAllBlindIndexesWithEnumValues(): void
+    {
+        $eR = (new EncryptedRow($this->brngRandom, 'contacts'));
+        $eR->addTextField('status');
+        $eR->addBlindIndex('status', new BlindIndex('status_idx'));
+
+        $rowWithBackedEnum = ['status' => TestBackedEnum::Active];
+        $indexes = $eR->getAllBlindIndexes($rowWithBackedEnum);
+        $this->assertArrayHasKey('status_idx', $indexes);
+
+        $rowWithUnitEnum = ['status' => TestUnitEnum::Approved];
+        $indexes = $eR->getAllBlindIndexes($rowWithUnitEnum);
+        $this->assertArrayHasKey('status_idx', $indexes);
     }
 }


### PR DESCRIPTION
Enable encryptRow() and blind indexes to accept PHP 8.1 enums by converting them to scalars before encryption/indexing.
Changes:
- Introduce enumToScalar() that converts BackedEnum to ->value and UnitEnum to ->name.
- Apply enum conversion in encryptRow
- Add tests for encryptRow and getAllBlindIndexes with both backed and pure enums.